### PR TITLE
fix(i18n): close remaining hardcoded UI strings on text audit

### DIFF
--- a/roast66/src/components/common/OrderList.tsx
+++ b/roast66/src/components/common/OrderList.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useI18n } from "../../i18n/LanguageContext";
 import Button from "./Button";
 
 export type OrderLineItem = {
@@ -14,6 +15,7 @@ type OrderListProps = {
 };
 
 const OrderList = ({ items, onQuantityChange, onRemove }: OrderListProps) => {
+  const { t } = useI18n();
   return (
     <ul className="space-y-2">
       {items.map((item, index) => (
@@ -30,7 +32,7 @@ const OrderList = ({ items, onQuantityChange, onRemove }: OrderListProps) => {
               className="w-16 p-1 border rounded"
             />
             <Button onClick={() => onRemove(index)} color="red">
-              Remove
+              {t("common.remove")}
             </Button>
           </div>
         </li>

--- a/roast66/src/i18n/LanguageContext.tsx
+++ b/roast66/src/i18n/LanguageContext.tsx
@@ -84,8 +84,31 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
     if (typeof window !== "undefined") {
       window.localStorage.setItem(LANGUAGE_STORAGE_KEY, locale);
     }
-    if (typeof document !== "undefined") {
-      document.documentElement.lang = locale;
+    if (typeof document === "undefined") {
+      return;
+    }
+    document.documentElement.lang = locale;
+    const bundle = translations[locale as keyof typeof translations];
+    const titleRaw = getNestedValue(bundle, "meta.pageTitle");
+    const titleFallback = getNestedValue(translations[DEFAULT_LOCALE], "meta.pageTitle");
+    const title =
+      typeof titleRaw === "string"
+        ? titleRaw
+        : typeof titleFallback === "string"
+          ? titleFallback
+          : "Roast 66 Coffee";
+    document.title = title;
+    const descRaw = getNestedValue(bundle, "meta.description");
+    const descFallback = getNestedValue(translations[DEFAULT_LOCALE], "meta.description");
+    const desc =
+      typeof descRaw === "string"
+        ? descRaw
+        : typeof descFallback === "string"
+          ? descFallback
+          : "";
+    const metaDesc = document.querySelector('meta[name="description"]');
+    if (metaDesc && desc) {
+      metaDesc.setAttribute("content", desc);
     }
   }, [locale]);
 

--- a/roast66/src/i18n/strings/en.ts
+++ b/roast66/src/i18n/strings/en.ts
@@ -7,6 +7,11 @@ export const en = {
   app: {
     skipToMain: "Skip to main content",
   },
+  meta: {
+    pageTitle: "Roast 66 Coffee",
+    description:
+      "Roast 66 Coffee — order drinks, track your order, and visit our shop.",
+  },
   language: {
     english: "English",
     spanish: "Español",
@@ -143,6 +148,9 @@ export const en = {
     orderPrefix: "Order",
     itemFallback: "Item",
     addOnFallback: "Add-on",
+    addOnsLeadIn: " + ",
+    addOnListSeparator: ", ",
+    notesSuffix: " ({{notes}})",
     total: "Total",
     emailUpdates: "We will send order status updates to",
     emailOptional: "Email updates are optional. Download your order summary for your records.",
@@ -180,6 +188,7 @@ export const en = {
   },
   common: {
     logOut: "Log out",
+    remove: "Remove",
   },
   admin: {
     dashboardTitle: "Admin Dashboard",

--- a/roast66/src/i18n/strings/es-MX.ts
+++ b/roast66/src/i18n/strings/es-MX.ts
@@ -7,6 +7,11 @@ export const esMx: Messages = {
   app: {
     skipToMain: "Saltar al contenido principal",
   },
+  meta: {
+    pageTitle: "Roast 66 Coffee",
+    description:
+      "Roast 66 Coffee — ordena bebidas, sigue tu pedido y visita nuestra tienda.",
+  },
   language: {
     english: "English",
     spanish: "Español",
@@ -147,6 +152,9 @@ export const esMx: Messages = {
     orderPrefix: "Pedido",
     itemFallback: "Artículo",
     addOnFallback: "Extra",
+    addOnsLeadIn: " + ",
+    addOnListSeparator: ", ",
+    notesSuffix: " ({{notes}})",
     total: "Total",
     emailUpdates: "Enviaremos actualizaciones del pedido a",
     emailOptional:
@@ -189,6 +197,7 @@ export const esMx: Messages = {
   },
   common: {
     logOut: "Cerrar sesión",
+    remove: "Quitar",
   },
   admin: {
     dashboardTitle: "Panel de administración",

--- a/roast66/src/i18n/strings/parity.test.ts
+++ b/roast66/src/i18n/strings/parity.test.ts
@@ -33,7 +33,7 @@ describe("i18n string bundles", () => {
     const esPaths = new Set(collectLeafPaths(esMx));
     const onlyEn = [...enPaths].filter((p) => !esPaths.has(p));
     const onlyEs = [...esPaths].filter((p) => !enPaths.has(p));
-    expect(onlyEn).toEqual([]);
-    expect(onlyEs).toEqual([]);
+    expect(onlyEn).toHaveLength(0);
+    expect(onlyEs).toHaveLength(0);
   });
 });

--- a/roast66/src/i18n/strings/parity.test.ts
+++ b/roast66/src/i18n/strings/parity.test.ts
@@ -33,7 +33,7 @@ describe("i18n string bundles", () => {
     const esPaths = new Set(collectLeafPaths(esMx));
     const onlyEn = [...enPaths].filter((p) => !esPaths.has(p));
     const onlyEs = [...esPaths].filter((p) => !enPaths.has(p));
-    expect(onlyEn, `Keys only in en: ${onlyEn.join(", ")}`).toEqual([]);
-    expect(onlyEs, `Keys only in es-MX: ${onlyEs.join(", ")}`).toEqual([]);
+    expect(onlyEn).toEqual([]);
+    expect(onlyEs).toEqual([]);
   });
 });

--- a/roast66/src/pages/AdminPage.tsx
+++ b/roast66/src/pages/AdminPage.tsx
@@ -74,7 +74,7 @@ function AdminPage() {
         >
           <div
             role="tablist"
-            aria-label="Admin sections"
+            aria-label={t("admin.tablistAriaLabel")}
             className="flex flex-wrap gap-0 border-b border-gray-200 bg-gray-50 px-2 pt-2"
           >
             {adminTabs.map(({ id, label }) => {

--- a/roast66/src/pages/OrderConfirmationPage.tsx
+++ b/roast66/src/pages/OrderConfirmationPage.tsx
@@ -104,9 +104,14 @@ function OrderConfirmationPage() {
               {item.quantity}x{" "}
               {item.menuItem?.name ?? item.MenuItem?.name ?? t("orderConfirmation.itemFallback")}
               {(item.addOns || []).length > 0
-                ? ` + ${item.addOns?.map((a) => a.menuItem?.name ?? a.MenuItem?.name).filter(Boolean).join(", ")}`
+                ? `${t("orderConfirmation.addOnsLeadIn")}${(item.addOns ?? [])
+                    .map((a) => a.menuItem?.name ?? a.MenuItem?.name)
+                    .filter(Boolean)
+                    .join(t("orderConfirmation.addOnListSeparator"))}`
                 : ""}
-              {item.notes ? ` (${item.notes})` : ""}
+              {item.notes
+                ? t("orderConfirmation.notesSuffix", { notes: item.notes })
+                : ""}
             </li>
           ))}
         </ul>

--- a/roast66/src/pages/OrderStatusPage.tsx
+++ b/roast66/src/pages/OrderStatusPage.tsx
@@ -291,7 +291,9 @@ function OrderStatusPage() {
 
       {order ? (
         <div className="bg-gray-50 rounded-lg p-4">
-          <p className="text-lg font-bold mb-2">Order #{order.id}</p>
+          <p className="text-lg font-bold mb-2">
+            {t("orderConfirmation.orderPrefix")} #{order.id}
+          </p>
           <p className="text-gray-600 mb-4">
             {order.customerName} • {dateTimeFormatter.format(new Date(order.orderDate ?? ""))}
           </p>


### PR DESCRIPTION
- Admin tablist aria-label uses admin.tablistAriaLabel
- Order status summary heading uses localized order prefix
- Order confirmation line items use strings for add-on lead-in, list separator, and notes
- common.remove for OrderList; meta.pageTitle and meta.description synced from locale
- Document title and meta description updated when locale changes

Made-with: Cursor