### PR TITLE
Control production database migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ CoffeeShopApi/appsettings.json
 
 # Misc
 .DS_Store
+screenshot.png
 *.log
 npm-debug.log*
 yarn-debug.log*
@@ -51,3 +52,4 @@ features.md
 *.md
 !README.md
 !**/README.md
+!docs/operations/*.md

--- a/CoffeeShopApi.Tests/PostgresMigrationLockTests.cs
+++ b/CoffeeShopApi.Tests/PostgresMigrationLockTests.cs
@@ -1,0 +1,67 @@
+using Npgsql;
+
+namespace CoffeeShopApi.Tests;
+
+public class PostgresMigrationLockTests
+{
+    [Fact]
+    [Trait("Category", "PostgreSQLIntegration")]
+    public async Task MigrationLock_BlocksAConcurrentMigrationConnection()
+    {
+        var connectionString = Environment.GetEnvironmentVariable(
+            "POSTGRES_INTEGRATION_CONNECTION_STRING");
+
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            Assert.False(
+                string.Equals(
+                    Environment.GetEnvironmentVariable("REQUIRE_POSTGRES_INTEGRATION_TESTS"),
+                    "true",
+                    StringComparison.OrdinalIgnoreCase),
+                "POSTGRES_INTEGRATION_CONNECTION_STRING is required for this test run.");
+            return;
+        }
+
+        await using var holder = new NpgsqlConnection(connectionString);
+        await holder.OpenAsync();
+        await ExecuteLockCommand(holder, "pg_advisory_lock");
+
+        var waiterAcquiredLock = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var waiter = Task.Run(async () =>
+        {
+            await using var connection = new NpgsqlConnection(connectionString);
+            await connection.OpenAsync();
+            await ExecuteLockCommand(connection, "pg_advisory_lock");
+            waiterAcquiredLock.SetResult();
+            await ExecuteLockCommand(connection, "pg_advisory_unlock");
+        });
+
+        try
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(500));
+            Assert.False(waiterAcquiredLock.Task.IsCompleted);
+
+            await ExecuteLockCommand(holder, "pg_advisory_unlock");
+            await waiterAcquiredLock.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await waiter;
+        }
+        finally
+        {
+            if (!waiterAcquiredLock.Task.IsCompleted)
+            {
+                await ExecuteLockCommand(holder, "pg_advisory_unlock");
+            }
+        }
+    }
+
+    private static async Task ExecuteLockCommand(
+        NpgsqlConnection connection,
+        string functionName)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"SELECT {functionName}({Program.MigrationLockKey})";
+        await command.ExecuteNonQueryAsync();
+    }
+}

--- a/CoffeeShopApi/Program.cs
+++ b/CoffeeShopApi/Program.cs
@@ -14,6 +14,8 @@ namespace CoffeeShopApi
     /// <summary>Entry point. Exposed for integration testing via WebApplicationFactory.</summary>
     public class Program
     {
+        internal const long MigrationLockKey = 7266677001;
+
         public static void Main(string[] args)
         {
             Log.Logger = new LoggerConfiguration()
@@ -59,7 +61,7 @@ namespace CoffeeShopApi
 
                 Console.WriteLine("Acquiring the database migration lock...");
                 context.Database.OpenConnection();
-                context.Database.ExecuteSqlRaw("SELECT pg_advisory_lock(7266677001)");
+                context.Database.ExecuteSqlRaw($"SELECT pg_advisory_lock({MigrationLockKey})");
                 try
                 {
                     Console.WriteLine("Applying database migrations...");
@@ -67,7 +69,7 @@ namespace CoffeeShopApi
                 }
                 finally
                 {
-                    context.Database.ExecuteSqlRaw("SELECT pg_advisory_unlock(7266677001)");
+                    context.Database.ExecuteSqlRaw($"SELECT pg_advisory_unlock({MigrationLockKey})");
                     context.Database.CloseConnection();
                 }
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,15 @@ Run backend tests:
 dotnet test CoffeeShopApi.Tests/CoffeeShopApi.Tests.csproj
 ```
 
+Run the PostgreSQL migration-lock integration test against a disposable database:
+
+```bash
+REQUIRE_POSTGRES_INTEGRATION_TESTS=true \
+POSTGRES_INTEGRATION_CONNECTION_STRING="$STAGING_DATABASE_URL" \
+dotnet test CoffeeShopApi.Tests/CoffeeShopApi.Tests.csproj \
+  --filter FullyQualifiedName~PostgresMigrationLockTests
+```
+
 Run the complete frontend gate:
 
 ```bash
@@ -247,6 +256,8 @@ Post-deploy verification:
 JWT rotation invalidates all staff devices because the application does not currently maintain per-device revocation records.
 
 ### Migration, rollback, and restore
+
+The provider-specific commands and decision criteria are maintained in [`docs/operations/supabase-database-runbook.md`](docs/operations/supabase-database-runbook.md).
 
 1. Confirm a current backup exists before deploying a migration.
 2. Prefer additive expand/migrate/contract changes that remain compatible during deployment.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - backend
 
   postgres-db:
-    image: postgres:latest
+    image: postgres:17
     environment:
       POSTGRES_DB: coffeedb
       POSTGRES_USER: ${POSTGRES_USER:-root}

--- a/docs/operations/restore-drill-2026-08-18.md
+++ b/docs/operations/restore-drill-2026-08-18.md
@@ -1,0 +1,122 @@
+# Restore drill: 2026-08-18
+
+## Scope
+
+- Production provider: Supabase
+- Source project: `Roast66Coffee` (`thfmvhqwlskvfgejpzwz`)
+- Source status at capture: `ACTIVE_HEALTHY`
+- Source PostgreSQL version: `17.6.1.054`
+- Restore target: local PostgreSQL database `roast66_restore_staging_20260818`
+- Target server: the isolated development Docker PostgreSQL service on `localhost:5432`
+- Operator: Codex, authenticated by the project owner
+- Status: restored and migrated; waiting for verification review
+
+The restore target is a dedicated database and is not used by the running API, which remains connected to `coffeedb`.
+
+## Backup record
+
+- Backup method: Supabase CLI `db dump`, split into roles, schema, and data
+- Backup completion window (UTC): 2026-08-18 16:15:29–16:16:10
+- Source recovery point: separate transaction-consistent snapshots taken by the three sequential dump operations
+- Roles file: `/tmp/roast66-production-20260818-roles.sql`
+  - Size: 297 bytes
+  - SHA-256: `25873cec56a2cc6514e204f420231777f85c03da818caa7090cdcdfa89776ecd`
+- Schema file: `/tmp/roast66-production-20260818-schema.sql`
+  - Size: 14,606 bytes
+  - SHA-256: `07336b8f83e77621c19d0a7164755c762a58a5827c0d06719440eb16674f8c15`
+- Data file: `/tmp/roast66-production-20260818-data.sql`
+  - Size: 15,539 bytes
+  - SHA-256: `43179a3b030b2d99a1a7a3101a1943148ef77fd4c6aed1b0fb8c5a4078e98066`
+- Application data file: `/tmp/roast66-production-20260818-public-data.sql`
+  - Completed (UTC): 2026-08-18 16:23:12
+  - Size: 6,696 bytes
+  - SHA-256: `12e655afdfe1b11dc797dbd53c219280fd31ab436885ac28a3294fd23f74cac8`
+
+Do not add a database URL, password, backup archive, or customer data to this repository.
+
+## Procedure
+
+1. Authenticate the Supabase CLI and link its temporary work directory to project `thfmvhqwlskvfgejpzwz`.
+2. Capture the roles, schema, and data as separate SQL files outside the repository:
+
+   ```bash
+   supabase db dump --linked --role-only -f /tmp/roast66-production-20260818-roles.sql
+   supabase db dump --linked -f /tmp/roast66-production-20260818-schema.sql
+   supabase db dump --linked --data-only --use-copy -f /tmp/roast66-production-20260818-data.sql
+   ```
+
+3. Record the timestamps, source PostgreSQL version, archive size, and SHA-256 above.
+4. Restore the archive into the empty staging target. This will be performed interactively after reviewing the backup record.
+5. Run the application migration command against the restored target only after restore verification.
+
+## Restore and migration execution
+
+The original backup files remained unchanged. For the vanilla PostgreSQL staging target, a temporary schema copy excluded Supabase-managed extensions, ownership, publication, and platform-role grants. Application data was re-exported with `--schema public` so Supabase-managed `auth` and `storage` schemas were not required locally.
+
+Final restore inputs:
+
+- Schema: `/tmp/roast66-production-20260818-schema-local-staging-v2.sql`
+- Data: `/tmp/roast66-production-20260818-public-data.sql`
+
+Final commands:
+
+```bash
+psql -X -v ON_ERROR_STOP=1 \
+  -d roast66_restore_staging_20260818 \
+  -f /tmp/roast66-production-20260818-schema-local-staging-v2.sql
+
+psql -X -v ON_ERROR_STOP=1 \
+  -d roast66_restore_staging_20260818 \
+  -f /tmp/roast66-production-20260818-public-data.sql
+
+docker compose run --rm --no-deps --entrypoint dotnet \
+  -e 'ConnectionStrings__DefaultConnection=<local-staging-connection>' \
+  backend CoffeeShopApi.dll migrate
+```
+
+Timings:
+
+- Schema restore: 0.42 seconds
+- Public data restore: 0.10 seconds
+- Successful application migration: 2.52 seconds
+
+Problems encountered:
+
+1. The unmodified schema requested Supabase-only `pgsodium` and other platform extensions unavailable in vanilla PostgreSQL.
+2. The full data dump contained Supabase-managed `auth` and `storage` sections; an application-only `public` data dump was captured instead.
+3. The floating `postgres:latest` Docker tag advanced to PostgreSQL 18 and rejected the existing PostgreSQL 17 volume. The Compose service was pinned to `postgres:17`, matching production's major version.
+4. Passing `dotnet CoffeeShopApi.dll migrate` as a Compose service command duplicated the image entrypoint and started the API. Overriding the entrypoint executed the intended command.
+5. The successful migration logged advisory-lock acquisition before applying migrations and exited normally.
+
+## Verification
+
+- Migration history: passed; staging advanced from 12 restored entries to all 13 repository migrations, ending with `20260813002904_AddOrderTrackingTokens`.
+- Source/staging row counts: passed.
+  - Menu items: 38 / 38
+  - Orders: 2 / 2
+  - Order items: 2 / 2
+  - Add-ons: 1 / 1
+  - Notification messages, notification settings, payment checkout drafts, and staff push subscriptions: 0 / 0
+- Menu integrity: passed; all 38 entries were readable, including the four `DRINKS` entries Energy Drink, Lemonade, Refresher, and Tesla.
+- Tracking-token migration: passed; both restored orders received distinct non-null tokens.
+- Stripe identifiers: not applicable; the backup contained no non-null order payment-intent identifiers.
+- Staging API health: passed; `GET /api/health` returned `200`.
+- Public menu smoke test: passed; `GET /api/menu` returned `200`.
+- Admin login smoke test: passed; valid local credentials returned `200` and a non-empty token. Credentials and token were not logged.
+- Private order tracking smoke test: passed; a restored order's private tracking endpoint returned `200` and an order DTO. The token was not logged and its temporary file was deleted immediately.
+- Verification API: isolated container `roast66-staging-verification` on `http://localhost:5002`, connected only to `roast66_restore_staging_20260818`.
+- Concurrent migration lock: passed. With a controlled session holding advisory lock `7266677001`, PostgreSQL reported one granted exclusive advisory lock and two ungranted exclusive waiters. After release, both concurrent migration commands acquired the lock in turn and exited `0`.
+- Automated lock coverage: passed. `PostgresMigrationLockTests.MigrationLock_BlocksAConcurrentMigrationConnection` verified against PostgreSQL 17 in required mode (689 ms).
+- Provider runbook: added at `docs/operations/supabase-database-runbook.md` with exact Supabase CLI backup, staging restore, replacement-project recovery, rollback, and cleanup procedures.
+- Cleanup: passed. The staging API container and `roast66_restore_staging_20260818` database were removed; temporary dumps, filtered schema copies, logs, and response files were securely deleted; temporary Supabase CLI/work directories were removed; and the local Supabase access token was deleted with `supabase logout`.
+- Backup retention after drill: no SQL dump was retained locally or in the repository. The checksums and drill evidence remain in this record; a future operational backup should be copied to approved encrypted off-site storage before local cleanup.
+
+## Results
+
+- Backup captured: passed
+- Restore completed: passed for application-owned schema and data
+- Restore verification: passed
+- Migration completed: passed
+- Concurrent migration-lock verification: passed
+- Runbook and cleanup documentation: passed
+- Final outcome: passed and cleaned up

--- a/docs/operations/supabase-database-runbook.md
+++ b/docs/operations/supabase-database-runbook.md
@@ -1,0 +1,141 @@
+# Supabase database operations runbook
+
+This runbook applies while Supabase project `thfmvhqwlskvfgejpzwz` is the production PostgreSQL provider. Never commit database URLs, passwords, access tokens, or dump files.
+
+## Prerequisites
+
+- Supabase CLI 2.x
+- Docker
+- PostgreSQL 17 client tools
+- An empty PostgreSQL 17 staging database
+- Enough protected local storage for the dump
+
+Authenticate and link a temporary work directory:
+
+```bash
+supabase login
+mkdir -p /tmp/roast66-supabase-workdir
+supabase init --workdir /tmp/roast66-supabase-workdir --yes
+supabase link \
+  --workdir /tmp/roast66-supabase-workdir \
+  --project-ref thfmvhqwlskvfgejpzwz
+```
+
+The link command can request the Supabase database password. Enter it interactively or use the operating system's credential storage; do not put it in shell history.
+
+## Create a backup
+
+Set `BACKUP_DATE` to the UTC date used in the filenames:
+
+```bash
+BACKUP_DATE=YYYYMMDD
+
+supabase db dump \
+  --workdir /tmp/roast66-supabase-workdir \
+  --linked --role-only \
+  -f "/tmp/roast66-production-${BACKUP_DATE}-roles.sql"
+
+supabase db dump \
+  --workdir /tmp/roast66-supabase-workdir \
+  --linked \
+  -f "/tmp/roast66-production-${BACKUP_DATE}-schema.sql"
+
+supabase db dump \
+  --workdir /tmp/roast66-supabase-workdir \
+  --linked --data-only --use-copy --schema public \
+  -f "/tmp/roast66-production-${BACKUP_DATE}-public-data.sql"
+```
+
+Record the project ref, PostgreSQL version, UTC completion times, byte sizes, and SHA-256 checksums in a dated drill record. Supabase free-tier recovery depends on exports retained outside Supabase, so copy the verified files to approved encrypted backup storage before deleting the temporary copies.
+
+## Restore into vanilla PostgreSQL staging
+
+The Supabase schema dump contains platform-managed extensions, ownership, publication, and role grants that vanilla PostgreSQL does not provide. Preserve the original dump and create a filtered staging copy:
+
+```bash
+sed -E \
+  -e '/^CREATE EXTENSION IF NOT EXISTS /d' \
+  -e '/^ALTER TABLE .* OWNER TO "postgres";$/d' \
+  -e '/^ALTER PUBLICATION "supabase_realtime" OWNER TO "postgres";$/d' \
+  -e '/^GRANT .* TO "service_role";$/d' \
+  -e '/^GRANT .* TO "postgres";$/d' \
+  -e '/^SET SESSION AUTHORIZATION "postgres";$/d' \
+  -e '/^RESET SESSION AUTHORIZATION;$/d' \
+  -e '/^ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" /d' \
+  "/tmp/roast66-production-${BACKUP_DATE}-schema.sql" \
+  > "/tmp/roast66-production-${BACKUP_DATE}-schema-local-staging.sql"
+```
+
+Restore only into a confirmed empty target. `ON_ERROR_STOP` makes either command fail immediately on the first SQL error:
+
+```bash
+psql -X -v ON_ERROR_STOP=1 \
+  "$STAGING_DATABASE_URL" \
+  -f "/tmp/roast66-production-${BACKUP_DATE}-schema-local-staging.sql"
+
+psql -X -v ON_ERROR_STOP=1 \
+  "$STAGING_DATABASE_URL" \
+  -f "/tmp/roast66-production-${BACKUP_DATE}-public-data.sql"
+```
+
+Run application migrations once against staging:
+
+```bash
+ConnectionStrings__DefaultConnection="$STAGING_DATABASE_URL" \
+  dotnet CoffeeShopApi.dll migrate
+```
+
+Verify migration history, table row counts, menu reads, admin login, private order tracking, payment identifiers when present, and `GET /api/health`.
+
+## Restore into a replacement Supabase project
+
+Use a new, empty Supabase project on the same PostgreSQL major version. Obtain its direct database URL from the Supabase dashboard and keep it out of shell history.
+
+Apply files in this order:
+
+```bash
+psql -X -v ON_ERROR_STOP=1 "$REPLACEMENT_DATABASE_URL" \
+  -f "/secure/backup/roast66-production-${BACKUP_DATE}-roles.sql"
+
+psql -X -v ON_ERROR_STOP=1 "$REPLACEMENT_DATABASE_URL" \
+  -f "/secure/backup/roast66-production-${BACKUP_DATE}-schema.sql"
+
+psql -X -v ON_ERROR_STOP=1 "$REPLACEMENT_DATABASE_URL" \
+  -f "/secure/backup/roast66-production-${BACKUP_DATE}-public-data.sql"
+```
+
+Do not point the production API at the replacement project until all staging verification checks pass. Update the API connection string in the deployment provider, deploy one API instance, run smoke tests, and only then resume normal traffic.
+
+## Deployment and rollback decision
+
+Before deploying a schema migration:
+
+1. Capture and checksum a fresh backup.
+2. Restore and migrate it in staging.
+3. Prefer additive, backward-compatible schema changes.
+4. Run the controlled migration step before new API instances receive traffic.
+
+After a migration has run, prefer a forward fix when any of these are true:
+
+- The migration changed or deleted data.
+- The previous application version is incompatible with the current schema.
+- Reversing the migration would require guessing or reconstructing values.
+- Production has accepted writes using the new schema.
+
+Roll back only the application image when the current database schema remains backward compatible with that image. Run an EF migration `Down` only when it has been tested against a restored backup and proven not to lose data.
+
+Use full database recovery into a replacement Supabase project when the production database is corrupted, important data was deleted, or a safe forward fix is impossible. Never restore destructively over the only production copy.
+
+## Cleanup and credential handling
+
+After the drill is accepted:
+
+1. Stop the isolated staging API.
+2. Drop only the explicitly named staging database.
+3. Securely delete temporary SQL dumps, filtered copies, logs, and response files under `/tmp`.
+4. Remove `/tmp/roast66-supabase-workdir` and the temporary CLI installation if it is no longer needed.
+5. Keep the checksum record, but never the production data, in Git.
+6. Run `supabase logout` only if the workstation should no longer retain Supabase access.
+7. Rotate the Supabase database password or access token if it was pasted into chat, written to an unprotected file, exposed in logs, or used on an untrusted machine. Routine CLI use through protected credential storage does not by itself require rotation.
+
+Record every removed target and whether an encrypted off-site backup remains available.


### PR DESCRIPTION
## Summary

- pin local PostgreSQL to version 17 to prevent accidental major-version upgrades
- centralize and integration-test the PostgreSQL advisory migration lock
- document Supabase CLI backup, staging restore, replacement-project recovery, rollback, and cleanup procedures
- record the completed production backup restore and migration drill
- document how to run the PostgreSQL integration test

## Why

Production migrations need to run once as a controlled deployment step, concurrent migration attempts must serialize, seed work must remain separate, and the recovery procedure needs tested evidence.

The restore drill used a Supabase production dump restored into an isolated PostgreSQL 17 staging database. It verified migration history, row counts, menu data, admin login, private tracking, health checks, and concurrent migration locking before cleaning up all temporary resources and credentials.

## Validation

- 42/42 backend tests pass
- required-mode PostgreSQL migration-lock integration test passes against PostgreSQL 17
- two concurrent migration processes were observed waiting behind the same advisory lock and both completed successfully after release
- staging restore, controlled migration, row-count comparison, menu verification, admin login, tracking lookup, and health checks passed
- `git diff --check` passes

Closes #69