### PR TITLE
Harden order-first online payments

### DIFF
--- a/CoffeeShopApi.Tests/Integration/ApiIntegrationTests.cs
+++ b/CoffeeShopApi.Tests/Integration/ApiIntegrationTests.cs
@@ -434,18 +434,9 @@ public class ApiIntegrationTests : IClassFixture<WebAppFactory>
     {
         var payload = new
         {
+            existingOrderId = 1,
             customerName = "Payment Test",
-            customerPhone = "5550001234",
-            orderItems = new[]
-            {
-                new
-                {
-                    menuItemId = 1,
-                    quantity = 1,
-                    notes = "No sugar",
-                    addOns = Array.Empty<object>()
-                }
-            }
+            customerPhone = "5550001234"
         };
 
         var response = await _client.PostAsJsonAsync("/api/payments/checkout-session", payload);
@@ -453,13 +444,12 @@ public class ApiIntegrationTests : IClassFixture<WebAppFactory>
     }
 
     [Fact]
-    public async Task CreateCheckoutSession_EmptyOrderItemsWithoutExistingOrder_ReturnsBadRequest()
+    public async Task CreateCheckoutSession_WithoutExistingOrder_ReturnsBadRequest()
     {
         var payload = new
         {
             customerName = "Payment Test",
-            customerPhone = "5550001234",
-            orderItems = Array.Empty<object>()
+            customerPhone = "5550001234"
         };
 
         var response = await _client.PostAsJsonAsync("/api/payments/checkout-session", payload);

--- a/CoffeeShopApi.Tests/PaymentServiceTests.cs
+++ b/CoffeeShopApi.Tests/PaymentServiceTests.cs
@@ -33,7 +33,24 @@ public class PaymentServiceTests
     }
 
     [Fact]
-    public async Task CheckoutAndPaidWebhook_AreProviderNeutralAndIdempotent()
+    public void PaymentConcurrencyMigration_AddsTokenWithoutRewritingPaymentData()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseNpgsql("Host=localhost;Database=migration-script-only;Username=test;Password=test")
+            .Options;
+        using var context = new ApplicationDbContext(options);
+        var migrator = context.GetService<IMigrator>();
+
+        var script = migrator.GenerateScript(
+            "20260827010000_GeneralizeSmsProvider",
+            "20260828000000_AddPaymentConcurrencyToken");
+
+        Assert.Contains("ADD concurrencytoken uuid NOT NULL", script);
+        Assert.DoesNotContain("DROP TABLE payments", script);
+    }
+
+    [Fact]
+    public async Task ExistingOrderCheckoutAndPaidWebhook_AreProviderNeutralAndIdempotent()
     {
         var gateway = new FakePaymentGateway();
         await using var services = BuildServices(gateway);
@@ -47,22 +64,31 @@ public class PaymentServiceTests
             Price = 4.50m,
             CategoryType = CategoryType.COFFEE
         });
+        var order = new Order
+        {
+            CustomerName = "Gateway Customer",
+            CustomerPhone = "5551234567",
+            TrackingToken = "test-tracking-token-12345678901234567890123",
+            OrderItems =
+            [
+                new OrderItem
+                {
+                    MenuItemId = 42,
+                    Quantity = 2,
+                    UnitPrice = 4.50m
+                }
+            ]
+        };
+        context.Orders.Add(order);
         await context.SaveChangesAsync();
 
         var paymentService = scope.ServiceProvider.GetRequiredService<PaymentService>();
         var checkout = await paymentService.CreateCheckoutAsync(
             new CheckoutSessionRequest
             {
+                ExistingOrderId = order.Id,
                 CustomerName = "Gateway Customer",
-                CustomerPhone = "5551234567",
-                OrderItems =
-                [
-                    new CheckoutOrderItemRequest
-                    {
-                        MenuItemId = 42,
-                        Quantity = 2
-                    }
-                ]
+                CustomerPhone = "5551234567"
             },
             "provider-neutral-key");
 
@@ -93,14 +119,54 @@ public class PaymentServiceTests
             "{}",
             new Dictionary<string, string>());
 
-        var order = await context.Orders.SingleAsync();
+        var savedOrder = await context.Orders.SingleAsync();
         await context.Entry(payment).ReloadAsync();
-        Assert.NotNull(order.PaidUtc);
-        Assert.Equal(FakePaymentGateway.Name, order.PaymentProvider);
-        Assert.Equal("fake-payment-123", order.PaymentReference);
-        Assert.Equal(order.Id, payment.OrderId);
+        Assert.NotNull(savedOrder.PaidUtc);
+        Assert.Equal(FakePaymentGateway.Name, savedOrder.PaymentProvider);
+        Assert.Equal("fake-payment-123", savedOrder.PaymentReference);
+        Assert.Equal(savedOrder.Id, payment.OrderId);
         Assert.Equal(PaymentStatuses.Paid, payment.Status);
         Assert.Equal("wallet", payment.Method);
+    }
+
+    [Fact]
+    public async Task PaymentConcurrencyToken_RejectsStaleWebhookUpdate()
+    {
+        var gateway = new FakePaymentGateway();
+        await using var services = BuildServices(gateway);
+
+        await using (var setupScope = services.CreateAsyncScope())
+        {
+            var setupContext = setupScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            setupContext.Payments.Add(new Payment
+            {
+                Provider = FakePaymentGateway.Name,
+                Status = PaymentStatuses.Pending,
+                Amount = 4.50m,
+                ProviderCheckoutId = "concurrent-checkout",
+                IdempotencyKey = "concurrent-key",
+                CustomerName = "Concurrent Customer",
+                CustomerPhone = string.Empty,
+                PayloadJson = "{}"
+            });
+            await setupContext.SaveChangesAsync();
+        }
+
+        await using var firstScope = services.CreateAsyncScope();
+        await using var secondScope = services.CreateAsyncScope();
+        var firstContext = firstScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var secondContext = secondScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var firstPayment = await firstContext.Payments.SingleAsync();
+        var secondPayment = await secondContext.Payments.SingleAsync();
+
+        firstPayment.Status = PaymentStatuses.Paid;
+        firstPayment.ConcurrencyToken = Guid.NewGuid();
+        secondPayment.Status = PaymentStatuses.Failed;
+        secondPayment.ConcurrencyToken = Guid.NewGuid();
+
+        await firstContext.SaveChangesAsync();
+        await Assert.ThrowsAsync<DbUpdateConcurrencyException>(
+            () => secondContext.SaveChangesAsync());
     }
 
     private static ServiceProvider BuildServices(IPaymentGateway gateway)
@@ -117,8 +183,9 @@ public class PaymentServiceTests
         services.AddSingleton<IConfiguration>(configuration);
         services.AddLogging();
         services.AddHttpClient();
+        var databaseName = $"payment-tests-{Guid.NewGuid():N}";
         services.AddDbContext<ApplicationDbContext>(options =>
-            options.UseInMemoryDatabase($"payment-tests-{Guid.NewGuid():N}"));
+            options.UseInMemoryDatabase(databaseName));
         services.AddScoped<OrderService>();
         services.AddScoped<NotificationSettingsService>();
         services.AddScoped<ISmsSender, DisabledSmsSender>();

--- a/CoffeeShopApi/Controllers/PaymentsController.cs
+++ b/CoffeeShopApi/Controllers/PaymentsController.cs
@@ -29,13 +29,10 @@ public class PaymentsController : ControllerBase
     {
         if (request.ExistingOrderId is null or <= 0)
         {
-            if (request.OrderItems == null || request.OrderItems.Count == 0)
+            return BadRequest(new
             {
-                return BadRequest(new
-                {
-                    message = "Order items are required unless you are prepaying an existing order."
-                });
-            }
+                message = "Create the order before starting online payment."
+            });
         }
 
         if (!_paymentService.IsConfigured())

--- a/CoffeeShopApi/Migrations/20260828000000_AddPaymentConcurrencyToken.cs
+++ b/CoffeeShopApi/Migrations/20260828000000_AddPaymentConcurrencyToken.cs
@@ -1,0 +1,29 @@
+using CoffeeShopApi.Data;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CoffeeShopApi.Migrations;
+
+[DbContext(typeof(ApplicationDbContext))]
+[Migration("20260828000000_AddPaymentConcurrencyToken")]
+public partial class AddPaymentConcurrencyToken : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<Guid>(
+            name: "concurrencytoken",
+            table: "payments",
+            type: "uuid",
+            nullable: false,
+            defaultValue: Guid.Empty);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "concurrencytoken",
+            table: "payments");
+    }
+}

--- a/CoffeeShopApi/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/CoffeeShopApi/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -371,6 +371,11 @@ namespace CoffeeShopApi.Migrations
                         .HasColumnType("timestamp with time zone")
                         .HasColumnName("confirmedbystaffutc");
 
+                    b.Property<Guid>("ConcurrencyToken")
+                        .IsConcurrencyToken()
+                        .HasColumnType("uuid")
+                        .HasColumnName("concurrencytoken");
+
                     b.Property<DateTime>("CreatedUtc")
                         .HasColumnType("timestamp with time zone")
                         .HasColumnName("createdutc");

--- a/CoffeeShopApi/Models/Payments/CheckoutSessionRequest.cs
+++ b/CoffeeShopApi/Models/Payments/CheckoutSessionRequest.cs
@@ -5,9 +5,12 @@ namespace CoffeeShopApi.Models.Payments;
 public class CheckoutSessionRequest
 {
     /// <summary>
-    /// When set, Checkout charges this existing order (prepay) instead of creating a new order after payment.
-    /// Phone must match the order; line items are taken from the stored order.
+    /// Checkout only settles an order that was already created. Phone must match the
+    /// order when present; otherwise the customer name must match. Line items and
+    /// prices are always taken from the stored order.
     /// </summary>
+    [Required]
+    [Range(1, int.MaxValue)]
     public int? ExistingOrderId { get; set; }
 
     [Required]
@@ -22,34 +25,4 @@ public class CheckoutSessionRequest
     public string? CustomerEmail { get; set; }
 
     public bool CustomerNotificationOptIn { get; set; }
-
-    /// <summary>Required for new orders; ignored when <see cref="ExistingOrderId"/> is set.</summary>
-    public List<CheckoutOrderItemRequest> OrderItems { get; set; } = [];
-}
-
-public class CheckoutOrderItemRequest
-{
-    [Range(1, int.MaxValue)]
-    public int MenuItemId { get; set; }
-
-    [Range(1, 100)]
-    public int Quantity { get; set; }
-
-    [StringLength(500)]
-    public string? Notes { get; set; }
-
-    public List<CheckoutAddOnItemRequest> AddOns { get; set; } = [];
-
-    public decimal? UnitPrice { get; set; }
-}
-
-public class CheckoutAddOnItemRequest
-{
-    [Range(1, int.MaxValue)]
-    public int MenuItemId { get; set; }
-
-    [Range(1, 100)]
-    public int Quantity { get; set; }
-
-    public decimal? UnitPrice { get; set; }
 }

--- a/CoffeeShopApi/Models/Payments/Payment.cs
+++ b/CoffeeShopApi/Models/Payments/Payment.cs
@@ -73,6 +73,10 @@ public class Payment
     [Column("orderid")]
     public int? OrderId { get; set; }
 
+    [ConcurrencyCheck]
+    [Column("concurrencytoken")]
+    public Guid ConcurrencyToken { get; set; } = Guid.NewGuid();
+
     public Order? Order { get; set; }
 }
 

--- a/CoffeeShopApi/Services/Payments/PaymentService.cs
+++ b/CoffeeShopApi/Services/Payments/PaymentService.cs
@@ -11,7 +11,6 @@ public sealed class PaymentService
     private readonly ApplicationDbContext _context;
     private readonly IConfiguration _configuration;
     private readonly OrderService _orderService;
-    private readonly NotificationService _notificationService;
     private readonly IReadOnlyDictionary<string, IPaymentGateway> _gateways;
     private readonly ILogger<PaymentService> _logger;
 
@@ -19,14 +18,12 @@ public sealed class PaymentService
         ApplicationDbContext context,
         IConfiguration configuration,
         OrderService orderService,
-        NotificationService notificationService,
         IEnumerable<IPaymentGateway> gateways,
         ILogger<PaymentService> logger)
     {
         _context = context;
         _configuration = configuration;
         _orderService = orderService;
-        _notificationService = notificationService;
         _gateways = gateways.ToDictionary(
             gateway => gateway.ProviderName,
             StringComparer.OrdinalIgnoreCase);
@@ -70,6 +67,26 @@ public sealed class PaymentService
         }
 
         var prepared = await PrepareCheckoutAsync(request, cancellationToken);
+
+        var pendingPayment = await _context.Payments
+            .AsNoTracking()
+            .Where(payment =>
+                payment.Provider == gateway.ProviderName &&
+                payment.OrderId == request.ExistingOrderId &&
+                payment.Status == PaymentStatuses.Pending)
+            .OrderByDescending(payment => payment.CreatedUtc)
+            .FirstOrDefaultAsync(cancellationToken);
+        if (pendingPayment != null)
+        {
+            var pendingCheckout = await gateway.GetCheckoutAsync(
+                pendingPayment.ProviderCheckoutId,
+                cancellationToken);
+            return new PaymentCheckoutResult(
+                pendingCheckout.CheckoutUrl,
+                pendingCheckout.ProviderCheckoutId,
+                gateway.ProviderName);
+        }
+
         var payment = new Payment
         {
             Provider = gateway.ProviderName,
@@ -80,7 +97,8 @@ public sealed class PaymentService
             IdempotencyKey = idempotencyKey,
             CustomerName = prepared.Payload.CustomerName,
             CustomerPhone = prepared.Payload.CustomerPhone ?? string.Empty,
-            PayloadJson = JsonSerializer.Serialize(prepared.Payload)
+            PayloadJson = JsonSerializer.Serialize(prepared.Payload),
+            OrderId = prepared.Payload.ExistingOrderId
         };
 
         var metadata = new Dictionary<string, string>
@@ -171,7 +189,11 @@ public sealed class PaymentService
             case GatewayPaymentStatus.Failed when payment.Status != PaymentStatuses.Paid:
                 payment.Status = PaymentStatuses.Failed;
                 payment.FailedUtc = DateTime.UtcNow;
-                await _context.SaveChangesAsync(cancellationToken);
+                payment.ConcurrencyToken = Guid.NewGuid();
+                await SaveWebhookChangesAsync(
+                    payment,
+                    PaymentStatuses.Failed,
+                    cancellationToken);
                 break;
             case GatewayPaymentStatus.Pending:
                 break;
@@ -187,48 +209,37 @@ public sealed class PaymentService
             _configuration["Stripe:FrontendBaseUrl"] ??
             "http://localhost:3000").TrimEnd('/');
 
-        if (request.ExistingOrderId is int existingOrderId && existingOrderId > 0)
+        if (request.ExistingOrderId is not int existingOrderId || existingOrderId <= 0)
         {
-            var order = await _orderService.GetOrderByIdAsync(existingOrderId, cancellationToken)
-                ?? throw new InvalidOperationException("Order not found.");
-            if (order.PaidUtc != null)
-            {
-                throw new InvalidOperationException("This order is already paid.");
-            }
-
-            ValidateCustomerIdentity(request, order);
-            var lineItems = BuildLineItemsFromOrder(order);
-            if (lineItems.Count == 0)
-            {
-                throw new InvalidOperationException("This order has no billable items.");
-            }
-
-            return new PreparedCheckout(
-                new CheckoutSessionRequest
-                {
-                    ExistingOrderId = existingOrderId,
-                    CustomerName = order.CustomerName,
-                    CustomerPhone = order.CustomerPhone ?? request.CustomerPhone ?? string.Empty,
-                    CustomerEmail = order.CustomerEmail ?? request.CustomerEmail,
-                    CustomerNotificationOptIn = order.CustomerNotificationOptIn || request.CustomerNotificationOptIn,
-                    OrderItems = []
-                },
-                lineItems,
-                $"{frontendBaseUrl}/order-status?checkout=success&token={order.TrackingToken}",
-                $"{frontendBaseUrl}/order-status?checkout=cancelled&token={order.TrackingToken}");
+            throw new InvalidOperationException("Create the order before starting online payment.");
         }
 
-        if (request.OrderItems.Count == 0)
+        var order = await _orderService.GetOrderByIdAsync(existingOrderId, cancellationToken)
+            ?? throw new InvalidOperationException("Order not found.");
+        if (order.PaidUtc != null)
         {
-            throw new InvalidOperationException("Order items are required for a new checkout.");
+            throw new InvalidOperationException("This order is already paid.");
         }
 
-        var requestedLineItems = await BuildLineItemsFromRequestAsync(request, cancellationToken);
+        ValidateCustomerIdentity(request, order);
+        var lineItems = BuildLineItemsFromOrder(order);
+        if (lineItems.Count == 0)
+        {
+            throw new InvalidOperationException("This order has no billable items.");
+        }
+
         return new PreparedCheckout(
-            request,
-            requestedLineItems,
-            $"{frontendBaseUrl}/order/confirmation?checkout=success",
-            $"{frontendBaseUrl}/order?checkout=cancelled");
+            new CheckoutSessionRequest
+            {
+                ExistingOrderId = existingOrderId,
+                CustomerName = order.CustomerName,
+                CustomerPhone = order.CustomerPhone ?? request.CustomerPhone ?? string.Empty,
+                CustomerEmail = order.CustomerEmail ?? request.CustomerEmail,
+                CustomerNotificationOptIn = order.CustomerNotificationOptIn || request.CustomerNotificationOptIn
+            },
+            lineItems,
+            $"{frontendBaseUrl}/order-status?checkout=success&token={order.TrackingToken}",
+            $"{frontendBaseUrl}/order-status?checkout=cancelled&token={order.TrackingToken}");
     }
 
     private async Task CompletePaymentAsync(Payment payment, CancellationToken cancellationToken)
@@ -240,70 +251,54 @@ public sealed class PaymentService
 
         var payload = JsonSerializer.Deserialize<CheckoutSessionRequest>(payment.PayloadJson)
             ?? throw new InvalidOperationException("Unable to deserialize payment checkout payload.");
+        if (payload.ExistingOrderId is not int existingOrderId || existingOrderId <= 0)
+        {
+            throw new InvalidOperationException("Payment is not linked to an existing order.");
+        }
+
         var paidUtc = DateTime.UtcNow;
-        Order? createdOrderToNotify = null;
+        var order = await _orderService.GetOrderByIdAsync(existingOrderId, cancellationToken)
+            ?? throw new InvalidOperationException("Payment order no longer exists.");
 
-        if (payload.ExistingOrderId is int existingOrderId && existingOrderId > 0)
-        {
-            var order = await _orderService.GetOrderByIdAsync(existingOrderId, cancellationToken)
-                ?? throw new InvalidOperationException("Prepay order no longer exists.");
-
-            order.PaidUtc ??= paidUtc;
-            order.PaymentProvider ??= payment.Provider;
-            order.PaymentReference ??= payment.ProviderPaymentId ?? payment.ProviderCheckoutId;
-            payment.OrderId = order.Id;
-            _context.Orders.Update(order);
-        }
-        else
-        {
-            var order = new Order
-            {
-                CustomerName = payload.CustomerName,
-                CustomerPhone = payload.CustomerPhone,
-                CustomerEmail = payload.CustomerEmail,
-                CustomerNotificationOptIn = payload.CustomerNotificationOptIn,
-                PaidUtc = paidUtc,
-                PaymentProvider = payment.Provider,
-                PaymentReference = payment.ProviderPaymentId ?? payment.ProviderCheckoutId,
-                OrderItems = payload.OrderItems.Select(item => new OrderItem
-                {
-                    MenuItemId = item.MenuItemId,
-                    Quantity = item.Quantity,
-                    Notes = item.Notes,
-                    UnitPrice = item.UnitPrice ?? 0,
-                    AddOns = item.AddOns.Select(addOn => new AddOn
-                    {
-                        MenuItemId = addOn.MenuItemId,
-                        Quantity = addOn.Quantity,
-                        UnitPrice = addOn.UnitPrice ?? 0
-                    }).ToList()
-                }).ToList()
-            };
-
-            var createdOrder = await _orderService.CreateOrderAsync(order, preserveSnapshotPrices: true);
-            payment.OrderId = createdOrder.Id;
-            createdOrderToNotify = createdOrder;
-        }
-
+        order.PaidUtc ??= paidUtc;
+        order.PaymentProvider ??= payment.Provider;
+        order.PaymentReference ??= payment.ProviderPaymentId ?? payment.ProviderCheckoutId;
+        payment.OrderId = order.Id;
         payment.Status = PaymentStatuses.Paid;
         payment.CompletedUtc = paidUtc;
         payment.FailedUtc = null;
-        await _context.SaveChangesAsync(cancellationToken);
+        payment.ConcurrencyToken = Guid.NewGuid();
+        await SaveWebhookChangesAsync(
+            payment,
+            PaymentStatuses.Paid,
+            cancellationToken);
+    }
 
-        if (createdOrderToNotify != null)
+    private async Task SaveWebhookChangesAsync(
+        Payment payment,
+        string completedStatus,
+        CancellationToken cancellationToken)
+    {
+        try
         {
-            try
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            _context.ChangeTracker.Clear();
+            var currentStatus = await _context.Payments
+                .AsNoTracking()
+                .Where(current => current.Id == payment.Id)
+                .Select(current => current.Status)
+                .SingleOrDefaultAsync(cancellationToken);
+
+            if (currentStatus == PaymentStatuses.Paid || currentStatus == completedStatus)
             {
-                await _notificationService.SendOrderNotificationAsync(createdOrderToNotify, cancellationToken);
+                return;
             }
-            catch (Exception ex)
-            {
-                _logger.LogError(
-                    ex,
-                    "Payment {PaymentId} completed, but notifications for order {OrderId} failed.",
-                    payment.Id,
-                    createdOrderToNotify.Id);
-            }
+
+            throw new PaymentWebhookRetryException(
+                "Another webhook changed the payment while it was being finalized.");
         }
     }
 
@@ -344,53 +339,6 @@ public sealed class PaymentService
         }
 
         return null;
-    }
-
-    private async Task<List<GatewayLineItem>> BuildLineItemsFromRequestAsync(
-        CheckoutSessionRequest request,
-        CancellationToken cancellationToken)
-    {
-        var menuIds = request.OrderItems
-            .Select(item => item.MenuItemId)
-            .Concat(request.OrderItems.SelectMany(item => item.AddOns.Select(addOn => addOn.MenuItemId)))
-            .Distinct()
-            .ToList();
-        var menuLookup = await _context.MenuItems
-            .Where(item => menuIds.Contains(item.Id))
-            .ToDictionaryAsync(item => item.Id, cancellationToken);
-
-        var lineItems = new List<GatewayLineItem>();
-        foreach (var item in request.OrderItems)
-        {
-            if (!menuLookup.TryGetValue(item.MenuItemId, out var menuItem))
-            {
-                throw new InvalidOperationException($"Menu item {item.MenuItemId} not found.");
-            }
-
-            item.UnitPrice = menuItem.EffectivePrice;
-            lineItems.Add(new GatewayLineItem(
-                menuItem.Name,
-                menuItem.Description,
-                item.UnitPrice.Value,
-                item.Quantity));
-
-            foreach (var addOn in item.AddOns)
-            {
-                if (!menuLookup.TryGetValue(addOn.MenuItemId, out var addOnItem))
-                {
-                    throw new InvalidOperationException($"Add-on item {addOn.MenuItemId} not found.");
-                }
-
-                addOn.UnitPrice = addOnItem.EffectivePrice;
-                lineItems.Add(new GatewayLineItem(
-                    $"{menuItem.Name} add-on: {addOnItem.Name}",
-                    addOnItem.Description,
-                    addOn.UnitPrice.Value,
-                    addOn.Quantity));
-            }
-        }
-
-        return lineItems;
     }
 
     private static List<GatewayLineItem> BuildLineItemsFromOrder(Order order)

--- a/README.md
+++ b/README.md
@@ -195,6 +195,10 @@ such as `Stripe__SecretKey` and `Stripe__WebhookSecret`. The legacy
 `POST /api/payments/webhook` route targets the default provider; provider-specific webhook
 routes use `POST /api/payments/{provider}/webhook`.
 
+Orders are created before online checkout, so payment availability never blocks order placement.
+The rollout, webhook, refund, reconciliation, and outage procedure is maintained in
+[`docs/operations/payment-rollout-runbook.md`](docs/operations/payment-rollout-runbook.md).
+
 SMS delivery is isolated behind `ISmsSender`. To add a provider, implement that contract,
 register the adapter in dependency injection, and expose a provider-specific authenticated
 delivery-status webhook that normalizes updates through `NotificationService`.

--- a/docs/operations/payment-rollout-runbook.md
+++ b/docs/operations/payment-rollout-runbook.md
@@ -1,0 +1,91 @@
+# Payment Rollout Runbook
+
+## Current rollout status
+
+Online payment is a release blocker until every item in the launch checklist below is complete.
+
+- Frontend: `https://roast66coffee-frontend.onrender.com`
+- API: `https://roast66coffee.onrender.com`
+- Environment: one prelaunch Render environment; there is no separate staging deployment
+- Database backup: the project owner confirmed a current backup on 2026-08-28
+- Stripe account: not created yet
+- Public domain: not configured yet
+- Operational owner for payment support, refunds, reconciliation, and outages: client
+- Alert destination: a client-owned private Discord channel
+
+Do not set `VITE_ENABLE_ONLINE_PAYMENTS=true` until the Stripe account, webhook, alerts, and test-mode validation are complete.
+
+## Payment behavior
+
+An order is always created before payment. A customer can place and track an unpaid order even when Stripe is unavailable or disabled. Online checkout only settles an existing order; a successful verified webhook marks that order paid and records `stripe` as its payment provider.
+
+The first launch should enable cards and eligible card wallets. Checkout leaves payment-method selection under Stripe Dashboard control so the client can accept additional methods later. Before enabling a delayed method, exercise its successful and failed asynchronous webhook paths and confirm that the customer-facing status remains accurate while payment is processing.
+
+## Stripe and Render setup
+
+1. The client owner creates and owns the Stripe account, completes identity and business verification, and connects the settlement bank account.
+2. Start in Stripe test mode.
+3. Enable cards and eligible wallets in Stripe payment-method settings.
+4. Set these API environment variables in Render without placing secret values in the repository:
+   - `Payments__DefaultProvider=stripe`
+   - `Payments__FrontendBaseUrl=https://roast66coffee-frontend.onrender.com`
+   - `Stripe__SecretKey=<Stripe secret key>`
+   - `Stripe__WebhookSecret=<endpoint signing secret>`
+5. Confirm `AllowedOrigins` contains `https://roast66coffee-frontend.onrender.com`.
+6. Create the Stripe webhook endpoint:
+   - `POST https://roast66coffee.onrender.com/api/payments/stripe/webhook`
+7. Subscribe it to:
+   - `checkout.session.completed`
+   - `checkout.session.async_payment_succeeded`
+   - `checkout.session.async_payment_failed`
+   - `payment_intent.payment_failed`
+8. Copy that endpoint's signing secret to `Stripe__WebhookSecret` and redeploy the API.
+9. Create a webhook in a private client-owned Discord channel. Keep its URL out of the repository and store it only in the selected monitoring relay's secret store.
+10. Configure the monitoring relay to notify that Discord channel about checkout errors, invalid signatures, retryable webhook failures, Stripe delivery failures, and paid payments without linked orders.
+11. Train the client owner to find a payment, match it to an order, issue and record a refund, reconcile a payment, disable online payment during an outage, and recognize which Discord alerts require immediate action.
+
+When the public domain is connected, update `AllowedOrigins`, `Payments__FrontendBaseUrl`, `VITE_API_URL`, the Stripe webhook URL, and this runbook together.
+
+## Test-mode validation
+
+Use the prelaunch Render environment and Stripe test mode:
+
+1. Place an order without paying and confirm it immediately appears in the admin order list without a paid badge.
+2. Open the order's private status link and start online payment.
+3. Pay with a Stripe test card and confirm the customer returns to the same private order-status page.
+4. Confirm the order changes to paid and the admin card shows `Paid · Stripe`.
+5. Repeat the payment action and replay the successful webhook concurrently. Confirm there is no second charge, no duplicate local payment, and only the existing order is updated.
+6. Send an invalid signature and confirm the endpoint returns `400`.
+7. Exercise failed and delayed test payments before enabling any delayed payment method.
+8. Confirm canceling Stripe leaves the order valid and unpaid.
+9. Confirm provider credentials and provider reference values never appear in a public order response.
+
+## Production enablement
+
+1. Confirm a fresh database backup.
+2. Confirm migrations `20260827000000_GeneralizePaymentProviders` and `20260828000000_AddPaymentConcurrencyToken` appear in `__EFMigrationsHistory`.
+3. Repeat the webhook setup with Stripe live-mode keys and the live endpoint signing secret.
+4. Complete a low-value live payment while the frontend flag is still disabled by starting checkout from a controlled test client.
+5. Reconcile the Stripe payment, local payment record, and linked order.
+6. Confirm the client owner has completed payment operations training and can receive a test Discord alert.
+7. Set `VITE_ENABLE_ONLINE_PAYMENTS=true` and rebuild/redeploy the static frontend.
+
+## Production domain
+
+1. Connect the production domain to the frontend and API as planned.
+2. Update `AllowedOrigins`, `Payments__FrontendBaseUrl`, and `VITE_API_URL` to the production origins.
+3. Update the Stripe webhook endpoint if the API hostname changes.
+4. Confirm checkout success and cancel returns use the production frontend domain.
+5. Repeat signature, webhook delivery, payment, and unpaid-order outage checks after the domain change.
+
+## Support, refunds, reconciliation, and outages
+
+The client owns these operational decisions and the private Discord alert channel.
+
+- Support: use the Stripe payment search and the admin order number to locate the payment. Never request or share secret keys.
+- Refunds: the client performs refunds in Stripe Dashboard and records the refund in the client's operational log. The current application does not automatically synchronize Stripe refunds back into the paid badge.
+- Reconciliation: compare Stripe successful payments with local paid payment records and linked orders. Treat any paid payment without a linked order as urgent.
+- Provider outage: keep order creation available, set `VITE_ENABLE_ONLINE_PAYMENTS=false`, and redeploy the frontend. Existing orders remain valid and can be paid another way.
+- Alerts: route Stripe webhook delivery failures and Render application alerts for checkout errors, invalid signatures, retryable webhook failures, and payments without linked orders to the private client Discord channel. Test the complete alert path before launch.
+
+Prefer disabling online payment and applying a forward fix. Do not run the provider-generalization migration `Down` in production.

--- a/render.yaml
+++ b/render.yaml
@@ -33,7 +33,7 @@ services:
       - key: Jwt__TokenExpiryInHours
         value: "8"
       - key: AllowedOrigins
-        value: "https://roast66-web.onrender.com"
+        value: "https://roast66coffee-frontend.onrender.com"
         sync: false
       - key: Order__DuplicateDetectionWindowMinutes
         value: "2"
@@ -50,7 +50,7 @@ services:
       - key: Payments__DefaultProvider
         value: "stripe"
       - key: Payments__FrontendBaseUrl
-        value: "https://roast66-web.onrender.com"
+        value: "https://roast66coffee-frontend.onrender.com"
       - key: Stripe__SecretKey
         sync: false
       - key: Stripe__WebhookSecret

--- a/roast66/src/components/Admin/ViewOrders.test.tsx
+++ b/roast66/src/components/Admin/ViewOrders.test.tsx
@@ -108,4 +108,24 @@ describe("ViewOrders", () => {
       "Order #3",
     ]);
   });
+
+  it("labels a Stripe-settled order as paid", async () => {
+    mockGet.mockResolvedValue({
+      data: [
+        {
+          ...completedOrder,
+          paidUtc: "2026-08-26T10:05:00Z",
+          paymentProvider: "stripe",
+        },
+      ],
+    });
+
+    render(
+      <LanguageProvider>
+        <ViewOrders />
+      </LanguageProvider>
+    );
+
+    expect(await screen.findByText("Paid · Stripe")).toBeInTheDocument();
+  });
 });

--- a/roast66/src/components/Admin/ViewOrders.tsx
+++ b/roast66/src/components/Admin/ViewOrders.tsx
@@ -27,6 +27,11 @@ function orderDateMs(order: OrderDto): number {
   return Number.isFinite(t) ? t : 0;
 }
 
+function paymentProviderLabel(order: OrderDto): string {
+  const provider = (order.paymentProvider ?? order.PaymentProvider ?? "online").trim();
+  return provider.charAt(0).toUpperCase() + provider.slice(1);
+}
+
 function ViewOrders() {
   const { t } = useI18n();
   const [orders, setOrders] = useState<OrderDto[]>([]);
@@ -215,6 +220,7 @@ function ViewOrders() {
             const notifications = orderNotifications[id] ?? [];
             const loadingNotifications = Boolean(loadingNotificationsByOrderId[id]);
             const lineItems: OrderLineItemDto[] = order.orderItems || order.OrderItems || [];
+            const isPaid = Boolean(order.paidUtc ?? order.PaidUtc);
 
             return (
               <Card
@@ -230,6 +236,13 @@ function ViewOrders() {
                   >
                     {getStatusLabel(status)}
                   </span>
+                  {isPaid ? (
+                    <span className="px-2 py-1 rounded bg-emerald-100 text-emerald-800 text-sm font-semibold">
+                      {t("adminOrders.paidWithProvider", {
+                        provider: paymentProviderLabel(order),
+                      })}
+                    </span>
+                  ) : null}
                   {isComplete ? (
                     <span className="text-sm font-medium text-green-800">
                       {t("adminOrders.completedNoAction")}

--- a/roast66/src/i18n/strings/en.ts
+++ b/roast66/src/i18n/strings/en.ts
@@ -198,7 +198,6 @@ export const en = {
     itemRemoved: "{{itemName}} removed from order.",
     orderRequiredError: "Please add at least one item to your order.",
     checkoutMissingUrl: "Missing checkout URL",
-    checkoutFailed: "Unable to start payment. Please try again.",
     submitFailed:
       "Failed to place the order. Please try again or check the console for details.",
     pageSubtitle: "Build your homemade drink for the road in just a few taps.",
@@ -220,7 +219,7 @@ export const en = {
     restoreNotFound:
       "We could not reload your order. Check the tracking code, then tap Check Status.",
     lookupFailed: "Failed to look up order.",
-    paymentReceived: "Payment received. Thank you!",
+    paymentSubmitted: "Payment submitted. We are confirming it now.",
     paymentCancelled: "Payment was cancelled.",
     paidOnline: "Paid online - thank you!",
     statusHeader: "Status",
@@ -260,6 +259,9 @@ export const en = {
     addOnListSeparator: ", ",
     notesSuffix: " ({{notes}})",
     total: "Total",
+    paymentOptional:
+      "Your order is confirmed. Pay by card or wallet now, or choose another payment method at pickup.",
+    viewPaymentOptions: "View payment options",
     emailUpdates: "We will send order status updates to",
     emailOptional: "Email updates are optional. Download your order summary for your records.",
     downloadSummary: "Download Order Summary",
@@ -332,6 +334,7 @@ export const en = {
     advanceMarkComplete: "Mark complete",
     advanceStatus: "Advance status",
     completedNoAction: "Completed — no further action",
+    paidWithProvider: "Paid · {{provider}}",
     refreshNotifications: "Refresh notifications",
     loading: "Loading...",
     customerLabel: "Customer:",

--- a/roast66/src/i18n/strings/es-MX.ts
+++ b/roast66/src/i18n/strings/es-MX.ts
@@ -202,7 +202,6 @@ export const esMx: Messages = {
     itemRemoved: "{{itemName}} fue eliminado del pedido.",
     orderRequiredError: "Agrega al menos un artículo a tu pedido.",
     checkoutMissingUrl: "Falta URL de pago",
-    checkoutFailed: "No se pudo iniciar el pago. Intenta de nuevo.",
     submitFailed:
       "No se pudo enviar el pedido. Intenta de nuevo o revisa la consola.",
     pageSubtitle:
@@ -225,7 +224,7 @@ export const esMx: Messages = {
     restoreNotFound:
       "No pudimos recargar tu pedido. Verifica el código y toca Ver estado.",
     lookupFailed: "No se pudo consultar el pedido.",
-    paymentReceived: "Pago recibido. Gracias.",
+    paymentSubmitted: "Pago enviado. Lo estamos confirmando.",
     paymentCancelled: "El pago fue cancelado.",
     paidOnline: "Pagado en línea — gracias.",
     statusHeader: "Estado",
@@ -267,6 +266,9 @@ export const esMx: Messages = {
     addOnListSeparator: ", ",
     notesSuffix: " ({{notes}})",
     total: "Total",
+    paymentOptional:
+      "Tu pedido está confirmado. Paga ahora con tarjeta o cartera digital, o elige otro método al recoger.",
+    viewPaymentOptions: "Ver opciones de pago",
     emailUpdates: "Enviaremos actualizaciones del pedido a",
     emailOptional:
       "Las actualizaciones por correo son opcionales. Descarga el resumen de tu pedido para tus registros.",
@@ -345,6 +347,7 @@ export const esMx: Messages = {
     advanceMarkComplete: "Marcar completado",
     advanceStatus: "Avanzar estado",
     completedNoAction: "Completado — sin acción adicional",
+    paidWithProvider: "Pagado · {{provider}}",
     refreshNotifications: "Actualizar notificaciones",
     loading: "Cargando...",
     customerLabel: "Cliente:",

--- a/roast66/src/pages/OrderConfirmationPage.tsx
+++ b/roast66/src/pages/OrderConfirmationPage.tsx
@@ -7,6 +7,10 @@ import { getOrderStatusFromDto } from "../constants/orderStatusParse";
 import type { OrderDto, OrderLineItemDto } from "../types/api";
 import { writeOrderStatusSession } from "../constants/orderStatusSession";
 
+const ENABLE_ONLINE_PAYMENTS =
+  import.meta.env.VITE_ENABLE_ONLINE_PAYMENTS === "true" ||
+  import.meta.env.VITE_ENABLE_STRIPE_CHECKOUT === "true";
+
 function OrderConfirmationPage() {
   const { locale, t } = useI18n();
   const location = useLocation();
@@ -18,6 +22,7 @@ function OrderConfirmationPage() {
   );
   const hasEmailUpdates = notificationOptIn && customerEmail.trim().length > 0;
   const trackingToken = order?.trackingToken ?? order?.TrackingToken ?? "";
+  const isPaid = Boolean(order?.paidUtc ?? order?.PaidUtc);
   const statusVal = order ? getOrderStatusFromDto(order) : 0;
 
   React.useEffect(() => {
@@ -122,6 +127,16 @@ function OrderConfirmationPage() {
         <p className="font-bold">
           {t("orderConfirmation.total")}: {currencyFormatter.format(total)}
         </p>
+        {ENABLE_ONLINE_PAYMENTS && !isPaid ? (
+          <div className="mt-4 border-t border-[#ddcdbf] pt-4">
+            <p className="text-sm text-[#5b4940] mb-3">
+              {t("orderConfirmation.paymentOptional")}
+            </p>
+            <Link to={`/order-status?token=${encodeURIComponent(trackingToken)}`}>
+              <Button color="green">{t("orderConfirmation.viewPaymentOptions")}</Button>
+            </Link>
+          </div>
+        ) : null}
         {hasEmailUpdates ? (
           <p className="text-sm text-[#5b4940] mt-2">
             {t("orderConfirmation.emailUpdates")} <strong>{customerEmail}</strong>.

--- a/roast66/src/pages/OrderPage.tsx
+++ b/roast66/src/pages/OrderPage.tsx
@@ -21,9 +21,6 @@ import type { MenuItemDto, OrderDto } from "../types/api";
 import PromotionPrice, { effectivePrice } from "../components/common/PromotionPrice";
 import "../styles/OrderPage.css";
 
-const ENABLE_ONLINE_PAYMENTS =
-  import.meta.env.VITE_ENABLE_ONLINE_PAYMENTS === "true" ||
-  import.meta.env.VITE_ENABLE_STRIPE_CHECKOUT === "true";
 const MOBILE_ORDER_MEDIA_QUERY = "(max-width: 960px)";
 const MAX_LINE_QUANTITY = 12;
 
@@ -405,26 +402,6 @@ function OrderPage() {
       submissionInFlightRef.current = false;
       setIsSubmitting(false);
     };
-
-    if (ENABLE_ONLINE_PAYMENTS) {
-      const idempotencyKey =
-        window.crypto?.randomUUID?.() || `${Date.now()}-${Math.random()}`;
-      try {
-        const response = await axiosInstance.post("/payments/checkout-session", orderData, {
-          headers: { "X-Idempotency-Key": idempotencyKey },
-        });
-        const checkoutUrl = response?.data?.checkoutUrl as string | undefined;
-        if (!checkoutUrl) {
-          throw new Error(t("order.checkoutMissingUrl"));
-        }
-        window.location.assign(checkoutUrl);
-      } catch (error: unknown) {
-        console.error("Checkout session creation failed:", error);
-        toast.error(t("order.checkoutFailed"));
-        resetSubmissionState();
-      }
-      return;
-    }
 
     try {
       const response = await axiosInstance.post<OrderDto>("/admin/orders", orderData);

--- a/roast66/src/pages/OrderStatusPage.tsx
+++ b/roast66/src/pages/OrderStatusPage.tsx
@@ -58,7 +58,7 @@ function OrderStatusPage() {
     }
 
     if (checkout === "success") {
-      toast.success(t("orderStatus.paymentReceived"));
+      toast.success(t("orderStatus.paymentSubmitted"));
     } else {
       toast.info(t("orderStatus.paymentCancelled"));
     }
@@ -161,7 +161,6 @@ function OrderStatusPage() {
           existingOrderId: order.id,
           customerName: order.customerName,
           customerPhone: order.customerPhone ?? "",
-          orderItems: [],
         },
         { headers: { "X-Idempotency-Key": idempotencyKey } }
       );

--- a/roast66/src/types/api.ts
+++ b/roast66/src/types/api.ts
@@ -51,6 +51,8 @@ export type OrderDto = {
   OrderItems?: OrderLineItemDto[];
   paidUtc?: string | null;
   PaidUtc?: string | null;
+  paymentProvider?: string | null;
+  PaymentProvider?: string | null;
 };
 
 export type NotificationLogEntry = {

--- a/scripts/ops/health-check.sh
+++ b/scripts/ops/health-check.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-API_HEALTH_URL="${API_HEALTH_URL:-https://roast66-api.onrender.com/api/health}"
+API_HEALTH_URL="${API_HEALTH_URL:-https://roast66coffee.onrender.com/api/health}"
 
 echo "Checking ${API_HEALTH_URL}"
 response="$(curl -sS -w '\n%{http_code}' "${API_HEALTH_URL}")"


### PR DESCRIPTION
## Summary

- require orders to exist before online checkout and keep order placement available without Stripe
- make paid/failed webhook updates concurrency-safe and label settled admin orders with their provider
- preserve the private order-status return path and clarify optional payment messaging
- correct the Render production origins and add the payment rollout runbook
- document client-owned Stripe onboarding, training, Discord alerts, domain setup, refunds, reconciliation, and outage handling

## Verification

- dotnet test CoffeeShopApi.Tests/CoffeeShopApi.Tests.csproj --no-restore -v:minimal (63 passed)
- npm test -- --run (104 passed)
- npm run build
- git diff --check

## Rollout

Advances #137. The issue should remain open until the client creates and verifies the Stripe account, configures and tests Discord alerts, connects the production domain, and completes test/live payment validation.