### PR TITLE
Remove footer motto

### DIFF
--- a/roast66/src/components/layout/Footer.tsx
+++ b/roast66/src/components/layout/Footer.tsx
@@ -19,8 +19,6 @@ const Footer = ({ year = new Date().getFullYear() }: FooterProps) => {
             <img src={logo} alt="" aria-hidden="true" />
             <span>{t("nav.brandName")}</span>
           </Link>
-          <span className="r66-footer-divider" aria-hidden="true">•</span>
-          <p className="r66-footer-motto">{t("footer.motto")}</p>
         </div>
 
         <nav className="r66-footer-links" aria-label={t("footer.navigationLabel")}>

--- a/roast66/src/i18n/strings/en.ts
+++ b/roast66/src/i18n/strings/en.ts
@@ -40,7 +40,6 @@ export const en = {
   },
   footer: {
     rightsReserved: "All rights reserved.",
-    motto: "Local roots. Open roads.",
     navigationLabel: "Footer navigation",
     instagramTitle: "Follow us on Instagram",
     instagram: "Instagram",

--- a/roast66/src/i18n/strings/es-MX.ts
+++ b/roast66/src/i18n/strings/es-MX.ts
@@ -40,7 +40,6 @@ export const esMx: Messages = {
   },
   footer: {
     rightsReserved: "Todos los derechos reservados.",
-    motto: "Raíces locales. Caminos abiertos.",
     navigationLabel: "Navegación del pie de página",
     instagramTitle: "Síguenos en Instagram",
     instagram: "Instagram",

--- a/roast66/src/styles/Customer.css
+++ b/roast66/src/styles/Customer.css
@@ -910,16 +910,6 @@
   text-transform: uppercase;
   white-space: nowrap;
 }
-.r66-footer-divider { color: #d9a574; }
-.r66-footer-motto {
-  margin: 0;
-  color: var(--r66-copper-on-dark);
-  font-size: 0.875rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  white-space: nowrap;
-}
 .r66-footer-links { display: flex; align-items: center; justify-content: center; gap: 1.75rem; }
 .r66-footer-links a {
   color: #f7e9dd;
@@ -959,7 +949,6 @@
   .r66-footer-brand-block { flex-wrap: wrap; }
   .r66-footer-brand,
   .r66-footer-brand span,
-  .r66-footer-motto,
   .r66-footer-links,
   .r66-footer-links a { min-width: 0; max-width: 100%; white-space: normal; overflow-wrap: anywhere; }
   .r66-footer-links { grid-column: auto; grid-row: auto; display: grid; grid-template-columns: minmax(0, 1fr); gap: 1rem; }


### PR DESCRIPTION
## Summary
- remove the footer motto and divider
- remove the unused English and Spanish motto strings
- remove the obsolete motto styling

## Validation
- npm test (107 tests passed)
- npm run lint
- npm run build