### PR TITLE
Remove unused plaintext-password User model

### DIFF
--- a/CoffeeShopApi/Models/User.cs
+++ b/CoffeeShopApi/Models/User.cs
@@ -1,8 +1,0 @@
-namespace CoffeeShopApi.Models;
-
-public class User
-{
-    public int Id { get; set; }
-    public required string Username { get; set; }
-    public required string Password { get; set; }
-}


### PR DESCRIPTION
## Summary
- remove the unused `CoffeeShopApi.Models.User` model with plaintext password storage
- leave the configured admin credential and JWT authentication path unchanged
- add no replacement table or migration

## Verification
- `dotnet test Roast66.sln --configuration Release --verbosity minimal` (75 passed)
- `dotnet ef migrations has-pending-model-changes` reports no model changes

Closes #169