### PR TITLE
Fix live menu schema migration startup

### DIFF
--- a/CoffeeShopApi.Tests/DatabaseReadinessHealthCheckTests.cs
+++ b/CoffeeShopApi.Tests/DatabaseReadinessHealthCheckTests.cs
@@ -11,7 +11,9 @@ public class DatabaseReadinessHealthCheckTests
     [Fact]
     public async Task Check_WhenDatabaseIsAvailable_ReturnsHealthy()
     {
-        var check = CreateCheck(_ => Task.FromResult(true));
+        var check = CreateCheck(
+            _ => Task.FromResult(true),
+            _ => Task.FromResult(false));
 
         var result = await check.CheckHealthAsync(new HealthCheckContext());
 
@@ -21,7 +23,9 @@ public class DatabaseReadinessHealthCheckTests
     [Fact]
     public async Task Check_WhenDatabaseIsUnavailable_ReturnsUnhealthy()
     {
-        var check = CreateCheck(_ => Task.FromResult(false));
+        var check = CreateCheck(
+            _ => Task.FromResult(false),
+            _ => Task.FromResult(false));
 
         var result = await check.CheckHealthAsync(new HealthCheckContext());
 
@@ -29,13 +33,28 @@ public class DatabaseReadinessHealthCheckTests
     }
 
     [Fact]
+    public async Task Check_WhenDatabaseHasPendingMigrations_ReturnsUnhealthy()
+    {
+        var check = CreateCheck(
+            _ => Task.FromResult(true),
+            _ => Task.FromResult(true));
+
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        Assert.Equal("The required database schema is not current.", result.Description);
+    }
+
+    [Fact]
     public async Task Check_WhenDatabaseTimesOut_ReturnsUnhealthy()
     {
-        var check = CreateCheck(async cancellationToken =>
-        {
-            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
-            return true;
-        });
+        var check = CreateCheck(
+            async cancellationToken =>
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                return true;
+            },
+            _ => Task.FromResult(false));
         using var timeout = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
 
         var result = await check.CheckHealthAsync(new HealthCheckContext(), timeout.Token);
@@ -104,15 +123,20 @@ public class DatabaseReadinessHealthCheckTests
     }
 
     private static DatabaseReadinessHealthCheck CreateCheck(
-        Func<CancellationToken, Task<bool>> probe) =>
+        Func<CancellationToken, Task<bool>> canConnect,
+        Func<CancellationToken, Task<bool>> hasPendingMigrations) =>
         new(
-            new StubDatabaseReadinessProbe(probe),
+            new StubDatabaseReadinessProbe(canConnect, hasPendingMigrations),
             NullLogger<DatabaseReadinessHealthCheck>.Instance);
 
     private sealed class StubDatabaseReadinessProbe(
-        Func<CancellationToken, Task<bool>> probe) : IDatabaseReadinessProbe
+        Func<CancellationToken, Task<bool>> canConnect,
+        Func<CancellationToken, Task<bool>> hasPendingMigrations) : IDatabaseReadinessProbe
     {
         public Task<bool> CanConnectAsync(CancellationToken cancellationToken) =>
-            probe(cancellationToken);
+            canConnect(cancellationToken);
+
+        public Task<bool> HasPendingMigrationsAsync(CancellationToken cancellationToken) =>
+            hasPendingMigrations(cancellationToken);
     }
 }

--- a/CoffeeShopApi.Tests/MenuHistoryPostgresTests.cs
+++ b/CoffeeShopApi.Tests/MenuHistoryPostgresTests.cs
@@ -124,6 +124,20 @@ public class MenuHistoryPostgresTests
         await using var connection = new NpgsqlConnection(adminBuilder.ConnectionString);
         await connection.OpenAsync();
         await using var command = connection.CreateCommand();
+        command.CommandText =
+            """
+            DO $$
+            BEGIN
+                IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+                    CREATE ROLE anon NOLOGIN;
+                END IF;
+                IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+                    CREATE ROLE authenticated NOLOGIN;
+                END IF;
+            END $$;
+            """;
+        await command.ExecuteNonQueryAsync();
+
         command.CommandText = $"CREATE DATABASE \"{databaseName}\"";
         await command.ExecuteNonQueryAsync();
 

--- a/CoffeeShopApi/Health/DatabaseReadinessHealthCheck.cs
+++ b/CoffeeShopApi/Health/DatabaseReadinessHealthCheck.cs
@@ -7,6 +7,7 @@ namespace CoffeeShopApi.Health;
 internal interface IDatabaseReadinessProbe
 {
     Task<bool> CanConnectAsync(CancellationToken cancellationToken);
+    Task<bool> HasPendingMigrationsAsync(CancellationToken cancellationToken);
 }
 
 internal sealed class EfCoreDatabaseReadinessProbe(ApplicationDbContext context)
@@ -14,6 +15,16 @@ internal sealed class EfCoreDatabaseReadinessProbe(ApplicationDbContext context)
 {
     public Task<bool> CanConnectAsync(CancellationToken cancellationToken) =>
         context.Database.CanConnectAsync(cancellationToken);
+
+    public async Task<bool> HasPendingMigrationsAsync(CancellationToken cancellationToken)
+    {
+        if (!context.Database.IsRelational())
+        {
+            return false;
+        }
+
+        return (await context.Database.GetPendingMigrationsAsync(cancellationToken)).Any();
+    }
 }
 
 internal sealed class DatabaseReadinessHealthCheck(
@@ -26,13 +37,19 @@ internal sealed class DatabaseReadinessHealthCheck(
     {
         try
         {
-            if (await probe.CanConnectAsync(cancellationToken))
+            if (!await probe.CanConnectAsync(cancellationToken))
             {
-                return HealthCheckResult.Healthy();
+                logger.LogWarning("Database readiness check reported that the database is unavailable.");
+                return HealthCheckResult.Unhealthy("The required database is unavailable.");
             }
 
-            logger.LogWarning("Database readiness check reported that the database is unavailable.");
-            return HealthCheckResult.Unhealthy("The required database is unavailable.");
+            if (await probe.HasPendingMigrationsAsync(cancellationToken))
+            {
+                logger.LogWarning("Database readiness check found pending schema migrations.");
+                return HealthCheckResult.Unhealthy("The required database schema is not current.");
+            }
+
+            return HealthCheckResult.Healthy();
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -15,8 +15,8 @@ RUN dotnet publish -c Release -o /app
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
 WORKDIR /app
 COPY --from=build /app .
-
-
+COPY docker/backend-entrypoint.sh /app/backend-entrypoint.sh
+RUN chmod 755 /app/backend-entrypoint.sh
 
 EXPOSE 80
-ENTRYPOINT ["dotnet", "CoffeeShopApi.dll"]
+ENTRYPOINT ["/app/backend-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The application is a React single-page frontend backed by an ASP.NET Core API an
 - Public order APIs use 256-bit tracking tokens instead of sequential IDs and customer identity.
 - Public tracking responses omit phone numbers, email addresses, provider IDs, and internal database fields.
 - Public order creation, tracking, login, and password-support endpoints are rate limited.
-- Production migrations run as a locked, one-time deployment step rather than during application startup.
+- Production migrations take a PostgreSQL advisory lock and finish before the API starts serving traffic.
 
 Online payments and external SMS are feature-gated and disabled by default until their production integrations are approved and hardened. Payments use a provider-neutral application service; Stripe is the included gateway. SMS uses a provider-neutral sender contract with a disabled default implementation, so no SMS vendor is installed or contacted by default.
 
@@ -208,7 +208,7 @@ See the checked-in `.env.example` and `appsettings.Example.json` files for the c
 
 ## Database Changes and Menu Data
 
-Normal API startup never applies migrations or seeds data.
+Direct `dotnet` API startup does not apply migrations or seed data. Backend container startup applies pending migrations before launching the API, but never seeds menu data.
 
 Create a migration locally:
 
@@ -222,7 +222,7 @@ Apply migrations from a published application:
 dotnet CoffeeShopApi.dll migrate
 ```
 
-The migration command takes a PostgreSQL advisory lock, applies pending EF migrations, and exits. Render invokes it as a pre-deploy command so migrations finish before new application instances receive traffic.
+The migration command takes a PostgreSQL advisory lock, applies pending EF migrations, and exits. Render invokes it as a pre-deploy command on paid services. The backend Docker entrypoint also runs it before starting the API so free services, which do not support pre-deploy commands, cannot launch against an outdated schema. Running both is safe because EF migrations are idempotent and the advisory lock serializes concurrent attempts.
 
 Menu seeding is intentionally separate from schema migration. Use either:
 
@@ -272,7 +272,7 @@ Deployment flow:
 2. Populate every `sync: false` secret in the Render dashboard.
 3. Confirm `Admin__Username`, `Admin__Password`, and `Jwt__Key` before the first production deployment.
 4. Confirm `AllowedOrigins`, `Payments__FrontendBaseUrl`, and `VITE_API_URL` use the actual Render URLs.
-5. Let the API pre-deploy command apply migrations.
+5. Confirm the API startup logs show a successful migration before the application starts.
 6. Seed the menu explicitly if this is a new database.
 
 Post-deploy verification:
@@ -311,7 +311,7 @@ The provider-specific commands and decision criteria are maintained in [`docs/op
 ### Monitoring and automation
 
 - Liveness endpoint: `GET /api/health` checks only that the API process can respond.
-- Readiness endpoint: `GET /api/health/ready` checks the required database connection and is used by Render for routing.
+- Readiness endpoint: `GET /api/health/ready` checks the required database connection and confirms that no EF migrations are pending; Render uses it for routing.
 - Payment, SMS, email, push, Supabase, and keep-alive targets do not gate readiness.
 - GitHub Actions run tests and security checks on pushes and pull requests.
 - Dependabot monitors npm and NuGet dependencies.

--- a/docker/backend-entrypoint.sh
+++ b/docker/backend-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -gt 0 ]; then
+  exec dotnet CoffeeShopApi.dll "$@"
+fi
+
+dotnet CoffeeShopApi.dll migrate
+exec dotnet CoffeeShopApi.dll


### PR DESCRIPTION
## Summary

- run the advisory-locked EF migration command before the backend container starts the API
- keep explicit container commands such as `initialize-local` working
- make readiness unhealthy when EF migrations are pending
- document the free-tier Render migration path

## Root cause

The deployed application queried `menuitems.is_archived`, but production had not applied `20260829000000_PreserveOrderHistoryFromMenuChanges`. Render pre-deploy commands are unavailable to free web services, so the configured migration command did not protect this deployment.

## Verification

- `dotnet test CoffeeShopApi.Tests/CoffeeShopApi.Tests.csproj --no-restore -v:minimal` (95 passed)
- built the backend Docker image successfully
- started it against disposable PostgreSQL 17 and confirmed the target migration completed before API startup
- confirmed `GET /api/health/ready` returned 200/healthy and `GET /api/menu` returned 200 with the `is_archived` query
