### PR TITLE
test: enforce database release contracts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+.playwright-cli
+**/bin
+**/obj
+roast66/dist
+roast66/node_modules
+roast66/test-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,47 @@ jobs:
           npm test
           npm run lint
           npm run build
+
+  release-contracts:
+    name: Render release contracts
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out candidate revision
+        uses: actions/checkout@v4
+        with:
+          path: candidate
+
+      - name: Check out deployment baseline
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.event.before }}
+          path: base
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: candidate/roast66/package-lock.json
+
+      - name: Install frontend and browser dependencies
+        working-directory: candidate/roast66
+        run: |
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Upgrade the baseline with the candidate Render image and smoke-test the built menu
+        run: |
+          candidate/scripts/ci/render-smoke.sh \
+            "$GITHUB_WORKSPACE/candidate" \
+            "$GITHUB_WORKSPACE/base"
+
+      - name: Upload browser traces on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: render-release-contract-browser-traces
+          path: candidate/roast66/test-results
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ node_modules/
 
 # Testing
 **/coverage/
+**/test-results/
 
 # Environment and secrets
 .env

--- a/CoffeeShopApi.Tests/DatabaseModelContractTests.cs
+++ b/CoffeeShopApi.Tests/DatabaseModelContractTests.cs
@@ -1,0 +1,35 @@
+using CoffeeShopApi.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace CoffeeShopApi.Tests;
+
+public class DatabaseModelContractTests
+{
+    [Fact]
+    public void EfModelAndLatestMigrationSnapshot_AreInSync()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseNpgsql("Host=localhost;Database=model_contract;Username=unused;Password=unused")
+            .Options;
+        using var context = new ApplicationDbContext(options);
+
+        var migrationsAssembly = context.GetService<IMigrationsAssembly>();
+        var snapshot = migrationsAssembly.ModelSnapshot
+            ?? throw new InvalidOperationException("The EF migration snapshot is missing.");
+        var modelDiffer = context.GetService<IMigrationsModelDiffer>();
+        var runtimeInitializer = context.GetService<IModelRuntimeInitializer>();
+        var snapshotModel = runtimeInitializer.Initialize(snapshot.Model);
+        var currentModel = context.GetService<IDesignTimeModel>().Model;
+        var operations = modelDiffer.GetDifferences(
+            snapshotModel.GetRelationalModel(),
+            currentModel.GetRelationalModel());
+
+        Assert.True(
+            operations.Count == 0,
+            "The EF model has changes that are not represented by the latest migration snapshot: " +
+            string.Join(", ", operations.Select(operation => operation.GetType().Name)));
+    }
+}

--- a/CoffeeShopApi.Tests/DatabaseReleasePostgresTests.cs
+++ b/CoffeeShopApi.Tests/DatabaseReleasePostgresTests.cs
@@ -1,0 +1,219 @@
+using CoffeeShopApi.Models;
+using CoffeeShopApi.Models.Payments;
+using CoffeeShopApi.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.Extensions.Configuration;
+using Npgsql;
+
+namespace CoffeeShopApi.Tests;
+
+[Collection(PostgresIntegrationCollection.Name)]
+public class DatabaseReleasePostgresTests
+{
+    [Fact]
+    [Trait("Category", "PostgreSQLIntegration")]
+    public async Task MigrationsProduceEveryEfMappedTableAndColumn()
+    {
+        await using var database = await PostgresTestDatabase.CreateAsync("roast66_schema_contract");
+        if (database == null)
+        {
+            return;
+        }
+
+        await using var context = database.CreateContext();
+        await context.Database.MigrateAsync();
+        await context.Database.MigrateAsync();
+
+        var knownMigrations = context.Database.GetMigrations().ToArray();
+        var appliedMigrations = (await context.Database.GetAppliedMigrationsAsync()).ToArray();
+        Assert.Equal(knownMigrations, appliedMigrations);
+        Assert.Empty(await context.Database.GetPendingMigrationsAsync());
+
+        var mappedColumns = GetMappedColumns(context.Model);
+        Assert.NotEmpty(mappedColumns);
+
+        await using var connection = new NpgsqlConnection(database.ConnectionString);
+        await connection.OpenAsync();
+        var identifierQuoter = new NpgsqlCommandBuilder();
+
+        foreach (var table in mappedColumns.OrderBy(entry => entry.Key.Schema)
+                     .ThenBy(entry => entry.Key.Table))
+        {
+            await using var command = connection.CreateCommand();
+            var columns = string.Join(
+                ", ",
+                table.Value.OrderBy(column => column)
+                    .Select(identifierQuoter.QuoteIdentifier));
+            command.CommandText =
+                $"SELECT {columns} FROM " +
+                $"{identifierQuoter.QuoteIdentifier(table.Key.Schema)}." +
+                $"{identifierQuoter.QuoteIdentifier(table.Key.Table)} LIMIT 0";
+            await command.ExecuteNonQueryAsync();
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "PostgreSQLIntegration")]
+    public async Task EfBackedReadAndWritePaths_ExecuteAgainstPostgres()
+    {
+        await using var database = await PostgresTestDatabase.CreateAsync("roast66_data_contract");
+        if (database == null)
+        {
+            return;
+        }
+
+        await using var context = database.CreateContext();
+        await context.Database.MigrateAsync();
+
+        var menuService = new MenuService(context);
+        var drink = await menuService.CreateMenuItemAsync(new MenuItem
+        {
+            Name = "PostgreSQL Contract Latte",
+            Description = "Exercises every mapped menu column",
+            Price = 5.25m,
+            CategoryType = CategoryType.COFFEE
+        });
+        var addOn = await menuService.CreateMenuItemAsync(new MenuItem
+        {
+            Name = "PostgreSQL Contract Flavor",
+            Description = "Exercises add-on snapshots",
+            Price = 0.75m,
+            CategoryType = CategoryType.FLAVORS
+        });
+
+        Assert.Contains(await menuService.GetMenuItemsAsync(), item => item.Id == drink.Id);
+        Assert.Contains(await menuService.GetAllMenuItemsAsync(), item => item.Id == addOn.Id);
+        Assert.NotNull(await menuService.GetMenuItemByIdAsync(drink.Id));
+        Assert.Equal(
+            MenuItemUpdateResult.Updated,
+            await menuService.SetPromotionAsync(drink.Id, "10%"));
+        Assert.True(await menuService.ArchiveMenuItemAsync(drink.Id));
+        Assert.True(await menuService.RestoreMenuItemAsync(drink.Id));
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Order:DuplicateDetectionWindowMinutes"] = "2"
+            })
+            .Build();
+        var orderService = new OrderService(context, configuration);
+        var order = await orderService.CreateOrderAsync(new Order
+        {
+            CustomerName = "Database Contract Customer",
+            CustomerPhone = "555-0100",
+            OrderItems =
+            [
+                new OrderItem
+                {
+                    MenuItemId = drink.Id,
+                    Quantity = 1,
+                    AddOns =
+                    [
+                        new AddOn
+                        {
+                            MenuItemId = addOn.Id,
+                            Quantity = 2
+                        }
+                    ]
+                }
+            ]
+        });
+
+        Assert.NotNull(await orderService.GetOrderByIdAsync(order.Id));
+        Assert.NotNull(await orderService.GetOrderByTrackingTokenAsync(order.TrackingToken));
+        Assert.Contains(await orderService.GetOrdersAsync(), item => item.Id == order.Id);
+        Assert.NotNull(await orderService.FindDuplicateOrderAsync(order));
+        Assert.NotNull(await orderService.GetOrderForCustomerAsync(
+            order.Id,
+            order.CustomerPhone,
+            null));
+        Assert.Equal(1, await orderService.GetCountSinceAsync(DateTime.UtcNow.AddMinutes(-5)));
+
+        var settingsService = new NotificationSettingsService(context);
+        await settingsService.SaveNotificationSettingsAsync(new NotificationSettings
+        {
+            AdminEmail = "admin@example.test",
+            SmsFromAddress = "+15550101"
+        });
+        Assert.Equal(
+            "admin@example.test",
+            (await settingsService.GetNotificationSettingsAsync())?.AdminEmail);
+
+        context.NotificationMessages.Add(new NotificationMessage
+        {
+            EventType = "database-contract",
+            RecipientRole = "admin",
+            RecipientPhone = string.Empty,
+            RecipientEmail = "admin@example.test",
+            Channel = "email",
+            TemplateKey = "database-contract",
+            DedupKey = $"database-contract-{Guid.NewGuid():N}",
+            CreatedUtc = DateTime.UtcNow.AddDays(-2),
+            UpdatedUtc = DateTime.UtcNow.AddDays(-2)
+        });
+        context.StaffPushSubscriptions.Add(new StaffPushSubscription
+        {
+            Endpoint = "https://push.example.test/database-contract",
+            P256Dh = "test-p256dh",
+            Auth = "test-auth"
+        });
+        context.Payments.Add(new Payment
+        {
+            Provider = "contract",
+            Status = PaymentStatuses.Pending,
+            Amount = 6.75m,
+            Currency = "USD",
+            ProviderCheckoutId = $"checkout-{Guid.NewGuid():N}",
+            IdempotencyKey = $"idempotency-{Guid.NewGuid():N}",
+            CustomerName = order.CustomerName,
+            CustomerPhone = order.CustomerPhone ?? string.Empty,
+            PayloadJson = "{}",
+            OrderId = order.Id
+        });
+        await context.SaveChangesAsync();
+
+        var retentionService = new NotificationRetentionService(context);
+        Assert.Equal(
+            1,
+            await retentionService.PurgeEmailNotificationsOlderThanAsync(
+                DateTime.UtcNow.AddDays(-1)));
+        Assert.Equal(1, await context.StaffPushSubscriptions.CountAsync());
+        Assert.Equal(1, await context.Payments.CountAsync());
+    }
+
+    private static Dictionary<(string Schema, string Table), HashSet<string>> GetMappedColumns(
+        IModel model)
+    {
+        var result = new Dictionary<(string Schema, string Table), HashSet<string>>();
+
+        foreach (var entityType in model.GetEntityTypes())
+        {
+            var tableName = entityType.GetTableName();
+            if (tableName == null)
+            {
+                continue;
+            }
+
+            var schema = entityType.GetSchema() ?? "public";
+            var table = StoreObjectIdentifier.Table(tableName, schema);
+            var key = (schema, tableName);
+            if (!result.TryGetValue(key, out var columns))
+            {
+                columns = [];
+                result[key] = columns;
+            }
+
+            foreach (var property in entityType.GetProperties())
+            {
+                var columnName = property.GetColumnName(table);
+                if (columnName != null)
+                {
+                    columns.Add(columnName);
+                }
+            }
+        }
+
+        return result;
+    }
+}

--- a/CoffeeShopApi.Tests/MenuHistoryPostgresTests.cs
+++ b/CoffeeShopApi.Tests/MenuHistoryPostgresTests.cs
@@ -8,162 +8,82 @@ using Npgsql;
 
 namespace CoffeeShopApi.Tests;
 
+[Collection(PostgresIntegrationCollection.Name)]
 public class MenuHistoryPostgresTests
 {
     [Fact]
     [Trait("Category", "PostgreSQLIntegration")]
     public async Task MigrationAndMenuMaintenance_PreserveHistoryAndRollback()
     {
-        var baseConnectionString = GetRequiredConnectionString();
-        if (baseConnectionString == null)
+        await using var database = await PostgresTestDatabase.CreateAsync("roast66_menu_history");
+        if (database == null)
         {
             return;
         }
 
-        var databaseName = $"roast66_menu_history_{Guid.NewGuid():N}";
-        var databaseConnectionString = await CreateDatabaseAsync(baseConnectionString, databaseName);
+        var databaseConnectionString = database.ConnectionString;
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseNpgsql(databaseConnectionString)
+            .Options;
 
-        try
+        await using (var context = new ApplicationDbContext(options))
         {
-            var options = new DbContextOptionsBuilder<ApplicationDbContext>()
-                .UseNpgsql(databaseConnectionString)
-                .Options;
-
-            await using (var context = new ApplicationDbContext(options))
-            {
-                var migrator = context.GetService<IMigrator>();
-                await migrator.MigrateAsync("20260828000000_AddPaymentConcurrencyToken");
-            }
-
-            await SeedPreMigrationOrderAsync(databaseConnectionString);
-
-            await using (var context = new ApplicationDbContext(options))
-            {
-                await context.Database.MigrateAsync();
-            }
-
-            await AssertSnapshotsAndSetNullDeleteAsync(databaseConnectionString);
-
-            await using (var context = new ApplicationDbContext(options))
-            {
-                context.MenuItems.Add(new MenuItem
-                {
-                    Name = "Menu before failed import",
-                    Description = "Must survive rollback",
-                    Price = 3m,
-                    CategoryType = CategoryType.COFFEE
-                });
-                await context.SaveChangesAsync();
-
-                var service = new MenuService(context);
-                await Assert.ThrowsAsync<DbUpdateException>(() =>
-                    service.BulkReplaceAsync(
-                    [
-                        new MenuItem
-                        {
-                            Name = null!,
-                            Description = "Invalid replacement",
-                            Price = 4m,
-                            CategoryType = CategoryType.COFFEE
-                        }
-                    ]));
-            }
-
-            await using (var verification = new ApplicationDbContext(options))
-            {
-                Assert.True(await verification.MenuItems.AnyAsync(
-                    item => item.Name == "Menu before failed import"));
-            }
-
-            await AddSeedFailureTriggerAsync(databaseConnectionString);
-            await using (var context = new ApplicationDbContext(options))
-            {
-                await Assert.ThrowsAsync<DbUpdateException>(() =>
-                    SeedMenuItems.SeedAsync(context));
-            }
-
-            await using (var verification = new ApplicationDbContext(options))
-            {
-                Assert.True(await verification.MenuItems.AnyAsync(
-                    item => item.Name == "Menu before failed import"));
-            }
-        }
-        finally
-        {
-            await DropDatabaseAsync(baseConnectionString, databaseName);
-        }
-    }
-
-    private static string? GetRequiredConnectionString()
-    {
-        var connectionString = Environment.GetEnvironmentVariable(
-            "POSTGRES_INTEGRATION_CONNECTION_STRING");
-        if (!string.IsNullOrWhiteSpace(connectionString))
-        {
-            return connectionString;
+            var migrator = context.GetService<IMigrator>();
+            await migrator.MigrateAsync("20260828000000_AddPaymentConcurrencyToken");
         }
 
-        Assert.False(
-            string.Equals(
-                Environment.GetEnvironmentVariable("REQUIRE_POSTGRES_INTEGRATION_TESTS"),
-                "true",
-                StringComparison.OrdinalIgnoreCase),
-            "POSTGRES_INTEGRATION_CONNECTION_STRING is required for this test run.");
-        return null;
-    }
+        await SeedPreMigrationOrderAsync(databaseConnectionString);
 
-    private static async Task<string> CreateDatabaseAsync(
-        string baseConnectionString,
-        string databaseName)
-    {
-        var adminBuilder = new NpgsqlConnectionStringBuilder(baseConnectionString)
+        await using (var context = new ApplicationDbContext(options))
         {
-            Database = "postgres",
-            Pooling = false
-        };
-        await using var connection = new NpgsqlConnection(adminBuilder.ConnectionString);
-        await connection.OpenAsync();
-        await using var command = connection.CreateCommand();
-        command.CommandText =
-            """
-            DO $$
-            BEGIN
-                IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
-                    CREATE ROLE anon NOLOGIN;
-                END IF;
-                IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
-                    CREATE ROLE authenticated NOLOGIN;
-                END IF;
-            END $$;
-            """;
-        await command.ExecuteNonQueryAsync();
+            await context.Database.MigrateAsync();
+        }
 
-        command.CommandText = $"CREATE DATABASE \"{databaseName}\"";
-        await command.ExecuteNonQueryAsync();
+        await AssertSnapshotsAndSetNullDeleteAsync(databaseConnectionString);
 
-        var databaseBuilder = new NpgsqlConnectionStringBuilder(baseConnectionString)
+        await using (var context = new ApplicationDbContext(options))
         {
-            Database = databaseName,
-            Pooling = false
-        };
-        return databaseBuilder.ConnectionString;
-    }
+            context.MenuItems.Add(new MenuItem
+            {
+                Name = "Menu before failed import",
+                Description = "Must survive rollback",
+                Price = 3m,
+                CategoryType = CategoryType.COFFEE
+            });
+            await context.SaveChangesAsync();
 
-    private static async Task DropDatabaseAsync(
-        string baseConnectionString,
-        string databaseName)
-    {
-        NpgsqlConnection.ClearAllPools();
-        var builder = new NpgsqlConnectionStringBuilder(baseConnectionString)
+            var service = new MenuService(context);
+            await Assert.ThrowsAsync<DbUpdateException>(() =>
+                service.BulkReplaceAsync(
+                [
+                    new MenuItem
+                    {
+                        Name = null!,
+                        Description = "Invalid replacement",
+                        Price = 4m,
+                        CategoryType = CategoryType.COFFEE
+                    }
+                ]));
+        }
+
+        await using (var verification = new ApplicationDbContext(options))
         {
-            Database = "postgres",
-            Pooling = false
-        };
-        await using var connection = new NpgsqlConnection(builder.ConnectionString);
-        await connection.OpenAsync();
-        await using var command = connection.CreateCommand();
-        command.CommandText = $"DROP DATABASE IF EXISTS \"{databaseName}\" WITH (FORCE)";
-        await command.ExecuteNonQueryAsync();
+            Assert.True(await verification.MenuItems.AnyAsync(
+                item => item.Name == "Menu before failed import"));
+        }
+
+        await AddSeedFailureTriggerAsync(databaseConnectionString);
+        await using (var context = new ApplicationDbContext(options))
+        {
+            await Assert.ThrowsAsync<DbUpdateException>(() =>
+                SeedMenuItems.SeedAsync(context));
+        }
+
+        await using (var verification = new ApplicationDbContext(options))
+        {
+            Assert.True(await verification.MenuItems.AnyAsync(
+                item => item.Name == "Menu before failed import"));
+        }
     }
 
     private static async Task SeedPreMigrationOrderAsync(string connectionString)

--- a/CoffeeShopApi.Tests/PostgresIntegrationCollection.cs
+++ b/CoffeeShopApi.Tests/PostgresIntegrationCollection.cs
@@ -1,0 +1,7 @@
+namespace CoffeeShopApi.Tests;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class PostgresIntegrationCollection
+{
+    public const string Name = "PostgreSQL integration";
+}

--- a/CoffeeShopApi.Tests/PostgresMigrationLockTests.cs
+++ b/CoffeeShopApi.Tests/PostgresMigrationLockTests.cs
@@ -2,6 +2,7 @@ using Npgsql;
 
 namespace CoffeeShopApi.Tests;
 
+[Collection(PostgresIntegrationCollection.Name)]
 public class PostgresMigrationLockTests
 {
     [Fact]

--- a/CoffeeShopApi.Tests/PostgresTestDatabase.cs
+++ b/CoffeeShopApi.Tests/PostgresTestDatabase.cs
@@ -1,0 +1,101 @@
+using CoffeeShopApi.Data;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+
+namespace CoffeeShopApi.Tests;
+
+internal sealed class PostgresTestDatabase : IAsyncDisposable
+{
+    private readonly string _baseConnectionString;
+
+    private PostgresTestDatabase(
+        string baseConnectionString,
+        string databaseName,
+        string connectionString)
+    {
+        _baseConnectionString = baseConnectionString;
+        DatabaseName = databaseName;
+        ConnectionString = connectionString;
+    }
+
+    public string DatabaseName { get; }
+    public string ConnectionString { get; }
+
+    public static async Task<PostgresTestDatabase?> CreateAsync(string namePrefix)
+    {
+        var baseConnectionString = Environment.GetEnvironmentVariable(
+            "POSTGRES_INTEGRATION_CONNECTION_STRING");
+        if (string.IsNullOrWhiteSpace(baseConnectionString))
+        {
+            Assert.False(
+                string.Equals(
+                    Environment.GetEnvironmentVariable("REQUIRE_POSTGRES_INTEGRATION_TESTS"),
+                    "true",
+                    StringComparison.OrdinalIgnoreCase),
+                "POSTGRES_INTEGRATION_CONNECTION_STRING is required for this test run.");
+            return null;
+        }
+
+        var databaseName = $"{namePrefix}_{Guid.NewGuid():N}";
+        var adminBuilder = new NpgsqlConnectionStringBuilder(baseConnectionString)
+        {
+            Database = "postgres",
+            Pooling = false
+        };
+
+        await using (var connection = new NpgsqlConnection(adminBuilder.ConnectionString))
+        {
+            await connection.OpenAsync();
+            await using var command = connection.CreateCommand();
+            command.CommandText =
+                """
+                DO $$
+                BEGIN
+                    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+                        CREATE ROLE anon NOLOGIN;
+                    END IF;
+                    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+                        CREATE ROLE authenticated NOLOGIN;
+                    END IF;
+                END $$;
+                """;
+            await command.ExecuteNonQueryAsync();
+
+            command.CommandText = $"CREATE DATABASE \"{databaseName}\"";
+            await command.ExecuteNonQueryAsync();
+        }
+
+        var databaseBuilder = new NpgsqlConnectionStringBuilder(baseConnectionString)
+        {
+            Database = databaseName,
+            Pooling = false
+        };
+        return new PostgresTestDatabase(
+            baseConnectionString,
+            databaseName,
+            databaseBuilder.ConnectionString);
+    }
+
+    public ApplicationDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseNpgsql(ConnectionString)
+            .Options;
+        return new ApplicationDbContext(options);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        NpgsqlConnection.ClearAllPools();
+        var builder = new NpgsqlConnectionStringBuilder(_baseConnectionString)
+        {
+            Database = "postgres",
+            Pooling = false
+        };
+        await using var connection = new NpgsqlConnection(builder.ConnectionString);
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"DROP DATABASE IF EXISTS \"{DatabaseName}\" WITH (FORCE)";
+        await command.ExecuteNonQueryAsync();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -237,14 +237,15 @@ Run backend tests:
 dotnet test CoffeeShopApi.Tests/CoffeeShopApi.Tests.csproj
 ```
 
-Run the PostgreSQL migration-lock integration test against a disposable database:
+Run all PostgreSQL migration, physical-schema, and EF-backed data-access contracts against a disposable database:
 
 ```bash
 REQUIRE_POSTGRES_INTEGRATION_TESTS=true \
 POSTGRES_INTEGRATION_CONNECTION_STRING="$STAGING_DATABASE_URL" \
-dotnet test CoffeeShopApi.Tests/CoffeeShopApi.Tests.csproj \
-  --filter FullyQualifiedName~PostgresMigrationLockTests
+dotnet test CoffeeShopApi.Tests/CoffeeShopApi.Tests.csproj
 ```
+
+These contracts fail when the EF model and migration snapshot diverge, a migrated PostgreSQL database is missing any mapped table or column, migration locking breaks, or core menu/order/notification/payment queries do not execute with Npgsql.
 
 Run the complete frontend gate:
 
@@ -256,7 +257,19 @@ npm run build
 npm audit
 ```
 
-The current baseline is 41 backend tests and 67 frontend tests. The production frontend build performs TypeScript checks before Vite bundles the application.
+Run the production release smoke with a candidate checkout and a baseline checkout:
+
+```bash
+cd roast66
+npm ci
+npx playwright install chromium
+cd ..
+scripts/ci/render-smoke.sh "$PWD" /path/to/baseline-checkout
+```
+
+The release smoke builds the same backend Dockerfile used by Render, migrates a baseline PostgreSQL 17 database containing representative menu and order data, proves migration failure prevents API startup, verifies migrations finish before the API listens, calls readiness and menu endpoints, builds the frontend with the candidate API URL, and confirms the known menu item renders in Chromium. GitHub Actions runs this as the dedicated `Render release contracts` job.
+
+The production frontend build performs TypeScript checks before Vite bundles the application.
 
 ## Render Deployment
 

--- a/docker/postgres/render-smoke-fixture.sql
+++ b/docker/postgres/render-smoke-fixture.sql
@@ -1,0 +1,97 @@
+WITH drink AS (
+    INSERT INTO menuitems (
+        name,
+        price,
+        description,
+        "CategoryType",
+        is_featured_on_home,
+        is_archived,
+        promotion_type,
+        promotion_value)
+    VALUES (
+        'CI Smoke Latte',
+        5.25,
+        'Known menu item preserved across the candidate deployment',
+        0,
+        false,
+        false,
+        NULL,
+        NULL)
+    RETURNING id
+), flavor AS (
+    INSERT INTO menuitems (
+        name,
+        price,
+        description,
+        "CategoryType",
+        is_featured_on_home,
+        is_archived,
+        promotion_type,
+        promotion_value)
+    VALUES (
+        'CI Smoke Flavor',
+        0.75,
+        'Known add-on preserved across the candidate deployment',
+        2,
+        false,
+        false,
+        NULL,
+        NULL)
+    RETURNING id
+), smoke_order AS (
+    INSERT INTO orders (
+        customername,
+        customerphone,
+        customeremail,
+        customernotificationoptin,
+        orderdate,
+        orderstatus,
+        trackingtoken)
+    VALUES (
+        'CI Smoke Customer',
+        '555-0199',
+        'smoke@example.test',
+        false,
+        now(),
+        0,
+        repeat('s', 43))
+    RETURNING id
+), line AS (
+    INSERT INTO orderitems (
+        orderid,
+        menuitemid,
+        quantity,
+        "Customer_Notes",
+        unit_price,
+        item_name,
+        item_description,
+        item_category_type)
+    SELECT
+        smoke_order.id,
+        drink.id,
+        1,
+        'Release smoke fixture',
+        5.25,
+        'CI Smoke Latte',
+        'Known menu item preserved across the candidate deployment',
+        0
+    FROM smoke_order, drink
+    RETURNING "Id"
+)
+INSERT INTO addons (
+    menuitemid,
+    quantity,
+    orderitemid,
+    unit_price,
+    item_name,
+    item_description,
+    item_category_type)
+SELECT
+    flavor.id,
+    1,
+    line."Id",
+    0.75,
+    'CI Smoke Flavor',
+    'Known add-on preserved across the candidate deployment',
+    2
+FROM flavor, line;

--- a/roast66/e2e/menu-smoke.spec.ts
+++ b/roast66/e2e/menu-smoke.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+
+test("the built menu renders data from the candidate API", async ({ page }) => {
+  const expectedMenuItem = process.env.SMOKE_MENU_ITEM ?? "CI Smoke Latte";
+  const menuResponsePromise = page.waitForResponse((response) => {
+    const url = new URL(response.url());
+    return url.pathname === "/api/menu";
+  });
+
+  await page.goto("/menu");
+
+  const menuResponse = await menuResponsePromise;
+  expect(menuResponse.ok()).toBe(true);
+  const menu = (await menuResponse.json()) as Array<{
+    name?: string;
+    isArchived?: boolean;
+  }>;
+  expect(menu).toContainEqual(
+    expect.objectContaining({
+      name: expectedMenuItem,
+      isArchived: false,
+    })
+  );
+
+  await expect(page.getByRole("heading", { name: "Our Menu" })).toBeVisible();
+  await expect(page.getByText(expectedMenuItem, { exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Drinks" })).toBeVisible();
+});

--- a/roast66/package-lock.json
+++ b/roast66/package-lock.json
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@playwright/test": "^1.62.1",
         "@testing-library/jest-dom": "^6.0.0",
         "@testing-library/react": "^14.0.0",
         "@types/node": "^22.10.0",
@@ -1193,6 +1194,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -5242,6 +5259,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/roast66/package.json
+++ b/roast66/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@playwright/test": "^1.62.1",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
     "@types/node": "^22.10.0",

--- a/roast66/playwright.config.ts
+++ b/roast66/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000,
+  },
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  reporter: "list",
+  outputDir: "test-results/render-smoke",
+  use: {
+    baseURL: process.env.SMOKE_WEB_URL ?? "http://127.0.0.1:4173",
+    trace: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/roast66/vite.config.ts
+++ b/roast66/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     outDir: "dist",
   },
   test: {
+    include: ["src/**/*.{test,spec}.{ts,tsx}"],
     environment: "jsdom",
     globals: false,
     setupFiles: "./src/setupTests.ts",

--- a/scripts/ci/render-smoke.sh
+++ b/scripts/ci/render-smoke.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+default_candidate=$(cd "$script_dir/../.." && pwd)
+candidate_context=$(realpath "${1:-$default_candidate}")
+base_context=$(realpath "${2:-$candidate_context}")
+
+suffix="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-1}-$$"
+network_name="roast66-release-$suffix"
+database_name="roast66-release-db-$suffix"
+api_name="roast66-release-api-$suffix"
+candidate_image="roast66-api-candidate:$suffix"
+base_image="roast66-api-base:$suffix"
+api_port="${SMOKE_API_PORT:-18080}"
+web_port="${SMOKE_WEB_PORT:-4173}"
+menu_item="CI Smoke Latte"
+menu_response=$(mktemp)
+api_log=$(mktemp)
+preview_log=$(mktemp)
+preview_pid=""
+
+cleanup() {
+  local status=$?
+  set +e
+  if [ "$status" -ne 0 ]; then
+    echo "Release smoke failed. Candidate API log:" >&2
+    docker logs "$api_name" >&2 2>/dev/null
+    echo "Built frontend preview log:" >&2
+    sed -n '1,200p' "$preview_log" >&2 2>/dev/null
+  fi
+  if [ -n "$preview_pid" ]; then
+    kill "$preview_pid" >/dev/null 2>&1
+    wait "$preview_pid" >/dev/null 2>&1
+  fi
+  docker rm -f "$api_name" "$database_name" >/dev/null 2>&1
+  docker network rm "$network_name" >/dev/null 2>&1
+  docker image rm "$candidate_image" "$base_image" >/dev/null 2>&1
+  rm -f "$menu_response" "$api_log" "$preview_log"
+  exit "$status"
+}
+trap cleanup EXIT
+
+wait_for_postgres() {
+  for _ in $(seq 1 30); do
+    if docker exec "$database_name" pg_isready -U roast66 -d coffeedb >/dev/null 2>&1; then
+      return
+    fi
+    sleep 1
+  done
+  echo "PostgreSQL did not become ready." >&2
+  return 1
+}
+
+start_candidate_api() {
+  docker run -d \
+    --name "$api_name" \
+    --network "$network_name" \
+    -p "127.0.0.1:$api_port:8080" \
+    -e PORT=8080 \
+    -e ASPNETCORE_ENVIRONMENT=Production \
+    -e "ConnectionStrings__DefaultConnection=Host=$database_name;Port=5432;Database=coffeedb;Username=roast66;Password=roast66-test" \
+    -e "AllowedOrigins=http://127.0.0.1:$web_port" \
+    -e Admin__Username=smoke-admin \
+    -e Admin__Password=SmokePassword_NotForProduction \
+    -e Jwt__Key=SmokeJwtSigningKey_NotForProduction_AtLeast32Chars \
+    -e Jwt__Issuer=Roast66Coffee \
+    -e Jwt__Audience=Roast66Coffee \
+    -e KeepAlive__Enabled=false \
+    "$candidate_image" >/dev/null
+}
+
+wait_for_api() {
+  for _ in $(seq 1 45); do
+    if ! docker inspect "$api_name" --format '{{.State.Running}}' 2>/dev/null | grep -q true; then
+      echo "Candidate API exited before becoming ready." >&2
+      return 1
+    fi
+    if curl --fail --silent --show-error \
+      "http://127.0.0.1:$api_port/api/health/ready" >/dev/null 2>&1; then
+      return
+    fi
+    sleep 1
+  done
+  echo "Candidate API did not become ready." >&2
+  return 1
+}
+
+assert_menu_api() {
+  curl --fail --silent --show-error \
+    "http://127.0.0.1:$api_port/api/menu" >"$menu_response"
+  grep -Fq "\"name\":\"$menu_item\"" "$menu_response"
+  grep -Fq '"isArchived":false' "$menu_response"
+}
+
+echo "Building the base backend image from $base_context"
+docker build -f "$base_context/Dockerfile.backend" -t "$base_image" "$base_context"
+
+echo "Building the candidate backend image from $candidate_context"
+docker build -f "$candidate_context/Dockerfile.backend" -t "$candidate_image" "$candidate_context"
+
+docker network create "$network_name" >/dev/null
+docker run --rm -d \
+  --name "$database_name" \
+  --network "$network_name" \
+  -e POSTGRES_DB=coffeedb \
+  -e POSTGRES_USER=roast66 \
+  -e POSTGRES_PASSWORD=roast66-test \
+  -v "$candidate_context/docker/postgres/init-local-roles.sql:/docker-entrypoint-initdb.d/10-local-roles.sql:ro" \
+  postgres:17 >/dev/null
+wait_for_postgres
+
+echo "Applying the base image migrations and loading representative data"
+docker run --rm \
+  --network "$network_name" \
+  -e ASPNETCORE_ENVIRONMENT=Development \
+  -e "ConnectionStrings__DefaultConnection=Host=$database_name;Port=5432;Database=coffeedb;Username=roast66;Password=roast66-test" \
+  "$base_image" migrate
+docker exec -i "$database_name" \
+  psql -v ON_ERROR_STOP=1 -U roast66 -d coffeedb \
+  <"$candidate_context/docker/postgres/render-smoke-fixture.sql"
+
+echo "Confirming a failed migration prevents the candidate API from starting"
+if docker run --rm \
+  -e ASPNETCORE_ENVIRONMENT=Testing \
+  "$candidate_image" >"$api_log" 2>&1; then
+  echo "Candidate image unexpectedly started after its migration command failed." >&2
+  exit 1
+fi
+grep -Fq 'The migrate command cannot run in Testing.' "$api_log"
+
+echo "Starting the candidate image through its production entrypoint"
+start_candidate_api
+wait_for_api
+assert_menu_api
+
+docker logs "$api_name" >"$api_log" 2>&1
+migration_line=$(grep -n -m1 'Database initialization successful.' "$api_log" | cut -d: -f1)
+listening_line=$(grep -n -m1 'Now listening on:' "$api_log" | cut -d: -f1)
+test -n "$migration_line"
+test -n "$listening_line"
+test "$migration_line" -lt "$listening_line"
+
+echo "Building and serving the frontend with the candidate API URL"
+if [ ! -d "$candidate_context/roast66/node_modules" ]; then
+  npm --prefix "$candidate_context/roast66" ci
+fi
+VITE_API_URL="http://127.0.0.1:$api_port/api" \
+VITE_USE_STATIC_MENU=false \
+  npm --prefix "$candidate_context/roast66" run build
+npm --prefix "$candidate_context/roast66" run preview -- \
+  --host 127.0.0.1 --port "$web_port" >"$preview_log" 2>&1 &
+preview_pid=$!
+
+for _ in $(seq 1 30); do
+  if curl --fail --silent --show-error \
+    "http://127.0.0.1:$web_port/menu" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+curl --fail --silent --show-error \
+  "http://127.0.0.1:$web_port/menu" >/dev/null
+
+echo "Verifying the built menu in Chromium"
+(
+  cd "$candidate_context/roast66"
+  PLAYWRIGHT_HTML_OPEN=never \
+  SMOKE_WEB_URL="http://127.0.0.1:$web_port" \
+  SMOKE_MENU_ITEM="$menu_item" \
+    npx playwright test e2e/menu-smoke.spec.ts \
+      --config=playwright.config.ts --project=chromium
+)
+
+echo "Restarting the candidate image to verify migration idempotence"
+docker rm -f "$api_name" >/dev/null
+start_candidate_api
+wait_for_api
+assert_menu_api
+
+echo "Render release smoke passed."


### PR DESCRIPTION
## Summary
- fail CI when the EF model, migration snapshot, or migrated PostgreSQL schema diverge
- exercise core EF/Npgsql menu, order, notification, and payment paths against PostgreSQL 17
- build the Render backend image, upgrade representative baseline data, and smoke-test the API and built menu in Chromium

## Local verification
- dotnet test Roast66.sln --configuration Release --no-restore --verbosity minimal (98 passed)
- PostgreSQLIntegration filter with REQUIRE_POSTGRES_INTEGRATION_TESTS=true (4 passed, 0 skipped)
- npm test (122 passed)
- npm run lint
- npm run build
- scripts/ci/render-smoke.sh candidate baseline (Playwright passed)