### PR TITLE
Upgrade backend to .NET 10 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "10.0.x"
 
       - name: Verify coverage reporting
         run: python3 -m unittest discover -s scripts/ci/tests -p 'test_*.py' -v

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
         if: matrix.language == 'csharp'
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "10.0.x"
 
       - name: Setup Node
         if: matrix.language == 'javascript'

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/CoffeeShopApi/bin/Debug/net8.0/CoffeeShopApi.dll",
+            "program": "${workspaceFolder}/CoffeeShopApi/bin/Debug/net10.0/CoffeeShopApi.dll",
             "args": [],
             "cwd": "${workspaceFolder}/CoffeeShopApi",
             "stopAtEntry": false,

--- a/CoffeeShopApi.Tests/CoffeeShopApi.Tests.csproj
+++ b/CoffeeShopApi.Tests/CoffeeShopApi.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.30" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.30" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/CoffeeShopApi.Tests/Integration/MenuResetApiTests.cs
+++ b/CoffeeShopApi.Tests/Integration/MenuResetApiTests.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -284,6 +285,7 @@ public class MenuResetApiTests : IClassFixture<WebAppFactory>
             builder.ConfigureTestServices(services =>
             {
                 services.RemoveAll<DbContextOptions<ApplicationDbContext>>();
+                services.RemoveAll<IDbContextOptionsConfiguration<ApplicationDbContext>>();
                 services.AddDbContext<ApplicationDbContext>(options =>
                     options.UseInMemoryDatabase(_databaseName));
             });

--- a/CoffeeShopApi.Tests/Integration/StaffPushOrderIntegrationTests.cs
+++ b/CoffeeShopApi.Tests/Integration/StaffPushOrderIntegrationTests.cs
@@ -6,6 +6,7 @@ using CoffeeShopApi.Services;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -108,6 +109,7 @@ public class StaffPushOrderIntegrationTests
             {
                 services.RemoveAll<ApplicationDbContext>();
                 services.RemoveAll<DbContextOptions<ApplicationDbContext>>();
+                services.RemoveAll<IDbContextOptionsConfiguration<ApplicationDbContext>>();
                 services.AddDbContext<ApplicationDbContext>(options =>
                     options.UseInMemoryDatabase(_databaseName));
                 services.RemoveAll<IStaffPushSender>();

--- a/CoffeeShopApi.Tests/Integration/WebAppFactory.cs
+++ b/CoffeeShopApi.Tests/Integration/WebAppFactory.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -114,6 +115,7 @@ public class WebAppFactory : WebApplicationFactory<Program>
             services.AddTransient<IStartupFilter, TestTransportIpStartupFilter>();
             services.RemoveAll<ApplicationDbContext>();
             services.RemoveAll<DbContextOptions<ApplicationDbContext>>();
+            services.RemoveAll<IDbContextOptionsConfiguration<ApplicationDbContext>>();
             services.AddDbContext<ApplicationDbContext>(options =>
                 options.UseInMemoryDatabase(_databaseName));
         });

--- a/CoffeeShopApi.Tests/OrderIdempotencyPostgresTests.cs
+++ b/CoffeeShopApi.Tests/OrderIdempotencyPostgresTests.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -112,6 +113,7 @@ public class OrderIdempotencyPostgresTests
             {
                 services.RemoveAll<ApplicationDbContext>();
                 services.RemoveAll<DbContextOptions<ApplicationDbContext>>();
+                services.RemoveAll<IDbContextOptionsConfiguration<ApplicationDbContext>>();
                 services.AddDbContext<ApplicationDbContext>(options => options.UseNpgsql(connectionString));
                 services.RemoveAll<IStaffPushNotificationQueue>();
                 services.AddSingleton<IStaffPushNotificationQueue>(NotificationQueue);

--- a/CoffeeShopApi.Tests/PostgresConnectionStringTests.cs
+++ b/CoffeeShopApi.Tests/PostgresConnectionStringTests.cs
@@ -15,6 +15,7 @@ public class PostgresConnectionStringTests
 
         Assert.True(parsed.Pooling);
         Assert.Equal(20, parsed.MaxPoolSize);
+        Assert.Equal(GssEncryptionMode.Disable, parsed.GssEncryptionMode);
     }
 
     [Fact]

--- a/CoffeeShopApi.Tests/TrustedProxyConfigurationTests.cs
+++ b/CoffeeShopApi.Tests/TrustedProxyConfigurationTests.cs
@@ -34,7 +34,7 @@ public class TrustedProxyConfigurationTests
         Assert.Equal("CF-Connecting-IP", options.ForwardedForHeaderName);
         Assert.Equal(1, options.ForwardLimit);
         Assert.Single(options.KnownProxies);
-        Assert.Single(options.KnownNetworks);
+        Assert.Single(options.KnownIPNetworks);
     }
 
     [Fact]

--- a/CoffeeShopApi/CoffeeShopApi.csproj
+++ b/CoffeeShopApi/CoffeeShopApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
@@ -11,17 +11,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.30" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.30" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.30" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.30">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
     <PackageReference Include="Stripe.net" Version="52.4.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.22.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="WebPush" Version="1.0.13" />
   </ItemGroup>
 

--- a/CoffeeShopApi/Data/PostgresConnectionString.cs
+++ b/CoffeeShopApi/Data/PostgresConnectionString.cs
@@ -26,6 +26,7 @@ internal static class PostgresConnectionString
 
         builder.Pooling = true;
         builder.MaxPoolSize = MaximumPoolSize;
+        builder.GssEncryptionMode = GssEncryptionMode.Disable;
         return builder.ConnectionString;
     }
 

--- a/CoffeeShopApi/Security/TrustedProxyConfiguration.cs
+++ b/CoffeeShopApi/Security/TrustedProxyConfiguration.cs
@@ -40,12 +40,12 @@ internal static class TrustedProxyConfiguration
         options.ForwardedForHeaderName = clientIpHeader;
         options.ForwardLimit = forwardLimit;
         options.KnownProxies.Clear();
-        options.KnownNetworks.Clear();
+        options.KnownIPNetworks.Clear();
 
         AddKnownProxies(options, section["KnownProxies"]);
         AddKnownNetworks(options, section["KnownNetworks"]);
 
-        if (options.KnownProxies.Count == 0 && options.KnownNetworks.Count == 0)
+        if (options.KnownProxies.Count == 0 && options.KnownIPNetworks.Count == 0)
         {
             throw new InvalidOperationException(
                 $"{SectionName}:KnownProxies or {SectionName}:KnownNetworks must contain " +
@@ -83,7 +83,7 @@ internal static class TrustedProxyConfiguration
                     $"{SectionName}:KnownNetworks contains an invalid CIDR network: '{value}'.");
             }
 
-            options.KnownNetworks.Add(new Microsoft.AspNetCore.HttpOverrides.IPNetwork(prefix, prefixLength));
+            options.KnownIPNetworks.Add(new System.Net.IPNetwork(prefix, prefixLength));
         }
     }
 

--- a/CoffeeShopApi/Startup.cs
+++ b/CoffeeShopApi/Startup.cs
@@ -52,14 +52,14 @@ namespace CoffeeShopApi
                 options.ForwardedForHeaderName = forwardedHeaders.ForwardedForHeaderName;
                 options.ForwardLimit = forwardedHeaders.ForwardLimit;
                 options.KnownProxies.Clear();
-                options.KnownNetworks.Clear();
+                options.KnownIPNetworks.Clear();
                 foreach (var proxy in forwardedHeaders.KnownProxies)
                 {
                     options.KnownProxies.Add(proxy);
                 }
-                foreach (var network in forwardedHeaders.KnownNetworks)
+                foreach (var network in forwardedHeaders.KnownIPNetworks)
                 {
-                    options.KnownNetworks.Add(network);
+                    options.KnownIPNetworks.Add(network);
                 }
             });
             services.AddDbContext<ApplicationDbContext>(options =>

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,5 +1,5 @@
 # Stage 1: Build the .NET Core application
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 # Copy the project file and restore dependencies
@@ -12,7 +12,7 @@ WORKDIR /src/CoffeeShopApi
 RUN dotnet publish -c Release -o /app
 
 # Stage 2: Use the ASP.NET Core runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 WORKDIR /app
 COPY --from=build /app .
 COPY docker/backend-entrypoint.sh /app/backend-entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Online payments and external SMS are feature-gated and disabled by default until
 | Area | Technology |
 | --- | --- |
 | Frontend | React 18, TypeScript, React Router 7, Axios, Tailwind CSS, Vite |
-| Backend | .NET 8, ASP.NET Core Web API, Entity Framework Core |
+| Backend | .NET 10 LTS, ASP.NET Core Web API, Entity Framework Core |
 | Database | PostgreSQL |
 | Authentication | ASP.NET Core Identity accounts and JWT bearer tokens for staff routes |
 | Testing | xUnit, ASP.NET integration tests, Vitest, Testing Library |
@@ -98,7 +98,7 @@ than extending the component with another cross-cutting effect.
 
 - Docker with Docker Compose for the recommended setup
 - Node.js 24 LTS and npm for frontend-only development (see `.node-version`)
-- .NET 8 SDK for backend development and EF migrations
+- .NET 10 LTS SDK for backend development and EF migrations
 - PostgreSQL when running the backend without Docker
 - Python 3 and ripgrep (`rg`) for the coverage summary and full local smoke
 

--- a/docs/operations/testing-and-release-readiness.md
+++ b/docs/operations/testing-and-release-readiness.md
@@ -132,7 +132,7 @@ npm test -- src/pages/OrderPage.test.tsx
 
 ## Full local smoke
 
-Prerequisites are Docker with Compose support, .NET 8, Node.js 20+, npm,
+Prerequisites are Docker with Compose support, .NET 10 LTS, Node.js 20+, npm,
 Python 3, ripgrep, and a Chromium browser installed for Playwright:
 
 ```bash


### PR DESCRIPTION
Closes #160

## Summary
- target the API and tests at .NET 10 LTS
- align ASP.NET Core, EF Core, Npgsql, and Serilog packages with supported .NET 10 releases
- update CI, CodeQL, Docker, debugger, and runtime documentation
- preserve proxy trust and PostgreSQL behavior across .NET 10 compatibility changes

## Verification
- `dotnet restore Roast66.sln`
- `dotnet build Roast66.sln --configuration Release` (0 warnings, 0 errors)
- `dotnet test Roast66.sln --configuration Release` (191 passed, 20 expected PostgreSQL skips)
- PostgreSQL harness (211 passed, 0 skipped)
- NuGet audit (no vulnerable direct or transitive packages)
- EF pending-model check (no model changes)
- backend Docker build and final Render release smoke
- fresh PostgreSQL migration, health/readiness, idempotent migration, and clean shutdown

No migration or schema snapshot was changed.